### PR TITLE
Proper 3-color, WCAG-AA color systems + contrast engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,24 @@ vb.tokens("aurora");    // CSS custom properties
 vb.json("aurora");      // structured token object
 ```
 
-Each direction ships a light + dark palette (oklch), a radius + shadow language
-matched to its "press personality", and display/body/mono fonts. Drop the CSS on
-`:root`, reference `var(--bg)`, `var(--fg)`, `var(--accent)`, `var(--radius)`,
-`var(--shadow-md)`, `var(--font-display)` in your components, and the whole UI
-themes — including a working dark mode.
+Each direction ships a **3-color system** (`--primary` / `--secondary` /
+`--tertiary`) plus surfaces and text, in light + dark (oklch), a radius + shadow
+language matched to its "press personality", and display/body/mono fonts. Drop
+the CSS on `:root`, reference `var(--bg)`, `var(--fg)`, `var(--primary)`,
+`var(--on-primary)`, `var(--radius)`, `var(--shadow-md)`, `var(--font-display)`
+in your components, and the whole UI themes — including a working dark mode.
+
+## Accessible by construction
+
+Every palette is **WCAG AA contrast-checked** (built-in oklch → WCAG engine). The
+text color for each brand fill (`--on-primary`, `--on-secondary`, `--on-tertiary`)
+is auto-picked for ≥4.5:1 contrast, and `fg`/`muted` clear AA on `bg`. Verify any
+direction — or gate CI on it:
+
+```bash
+npx vibebrand check brutalist   # per-pair ratio + WCAG level
+npx vibebrand check --all       # exits 1 if any pair is below AA
+```
 
 ## The directions
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
+    "test": "tsup && node dist/cli.js check --all",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1,22 +1,25 @@
 /**
  * The vibebrand direction catalog — distinct, emotion-tagged brand worlds.
- * Each is a full design-system starting point: palette (light + dark), a font
- * pairing, a signature visual device, and a button "press personality".
+ * Each ships a proper 3-color system (primary / secondary / tertiary) plus
+ * surfaces and text, in light AND dark, all contrast-checked to WCAG AA by the
+ * token generator (see contrast.ts + tokens.ts). Colors are oklch.
  *
- * Productizes the `saas-brand-system` skill's style catalog. Colors are oklch.
+ * Productizes the `saas-brand-system` skill's style catalog.
  */
 
 export interface Palette {
   /** page background */
   bg: string;
-  /** primary text / ink */
+  /** primary text — MUST hit WCAG AA (4.5:1) on bg */
   fg: string;
-  /** the one (or first) brand accent */
-  accent: string;
-  /** secondary accent / support */
-  accentAlt: string;
-  /** muted surface */
+  /** secondary/muted text — AA-large on bg */
   muted: string;
+  /** brand color 1 (the lead) */
+  primary: string;
+  /** brand color 2 */
+  secondary: string;
+  /** brand color 3 / pop accent */
+  tertiary: string;
 }
 
 export interface BrandDirection {
@@ -24,14 +27,12 @@ export interface BrandDirection {
   name: string;
   /** the single emotion this world targets */
   emotion: string;
-  /** one-line description */
   blurb: string;
   light: Palette;
   dark: Palette;
   fonts: { display: string; body: string; mono: string };
-  /** the signature visual device carried across the design */
   signature: string;
-  /** how buttons behave on press — where the brand lives */
+  /** where the brand lives — how buttons behave on press */
   press: "glow-inset" | "gradient-lift" | "hard-stamp" | "restrained";
   radius: "sharp" | "soft" | "round";
 }
@@ -42,8 +43,8 @@ export const DIRECTIONS: BrandDirection[] = [
     name: "Signal",
     emotion: "alive · fast · technical",
     blurb: "Terminal-meets-neon. A signal that fires and travels.",
-    light: { bg: "oklch(0.99 0.003 250)", fg: "oklch(0.16 0.01 250)", accent: "oklch(0.62 0.14 210)", accentAlt: "oklch(0.72 0.19 130)", muted: "oklch(0.96 0.005 250)" },
-    dark: { bg: "oklch(0.15 0.012 250)", fg: "oklch(0.97 0.006 250)", accent: "oklch(0.82 0.16 200)", accentAlt: "oklch(0.88 0.20 130)", muted: "oklch(0.22 0.012 250)" },
+    light: { bg: "oklch(0.99 0.003 250)", fg: "oklch(0.16 0.01 250)", muted: "oklch(0.45 0.02 250)", primary: "oklch(0.52 0.14 210)", secondary: "oklch(0.50 0.16 145)", tertiary: "oklch(0.52 0.22 320)" },
+    dark: { bg: "oklch(0.15 0.012 250)", fg: "oklch(0.97 0.006 250)", muted: "oklch(0.70 0.02 250)", primary: "oklch(0.82 0.16 200)", secondary: "oklch(0.88 0.20 130)", tertiary: "oklch(0.72 0.20 320)" },
     fonts: { display: "Space Grotesk", body: "Inter", mono: "JetBrains Mono" },
     signature: "live dispatch console + light pulses travelling wires from one node to many",
     press: "glow-inset",
@@ -54,8 +55,8 @@ export const DIRECTIONS: BrandDirection[] = [
     name: "Fan-out / Prism",
     emotion: "delight · joy",
     blurb: "One white beam refracts through a prism into colored beams.",
-    light: { bg: "oklch(0.98 0.012 90)", fg: "oklch(0.20 0.02 330)", accent: "oklch(0.66 0.28 350)", accentAlt: "oklch(0.75 0.18 45)", muted: "oklch(0.95 0.02 60)" },
-    dark: { bg: "oklch(0.17 0.03 330)", fg: "oklch(0.96 0.01 330)", accent: "oklch(0.70 0.26 350)", accentAlt: "oklch(0.78 0.18 45)", muted: "oklch(0.24 0.03 330)" },
+    light: { bg: "oklch(0.98 0.012 90)", fg: "oklch(0.20 0.02 330)", muted: "oklch(0.48 0.04 330)", primary: "oklch(0.55 0.24 350)", secondary: "oklch(0.62 0.18 45)", tertiary: "oklch(0.52 0.20 285)" },
+    dark: { bg: "oklch(0.17 0.03 330)", fg: "oklch(0.96 0.01 330)", muted: "oklch(0.72 0.04 330)", primary: "oklch(0.70 0.26 350)", secondary: "oklch(0.78 0.18 45)", tertiary: "oklch(0.68 0.20 285)" },
     fonts: { display: "Sora", body: "Inter", mono: "JetBrains Mono" },
     signature: "a prism splitting the event beam into per-destination colored beams",
     press: "gradient-lift",
@@ -65,9 +66,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "blueprint",
     name: "Blueprint",
     emotion: "trust · precision",
-    blurb: "Premium enterprise. Engineering grid, glass, one indigo signal.",
-    light: { bg: "oklch(0.99 0.003 265)", fg: "oklch(0.20 0.015 265)", accent: "oklch(0.52 0.20 275)", accentAlt: "oklch(0.56 0.22 305)", muted: "oklch(0.96 0.006 265)" },
-    dark: { bg: "oklch(0.16 0.015 265)", fg: "oklch(0.96 0.006 265)", accent: "oklch(0.60 0.21 278)", accentAlt: "oklch(0.56 0.22 305)", muted: "oklch(0.22 0.015 265)" },
+    blurb: "Premium enterprise. Engineering grid, glass, indigo signal.",
+    light: { bg: "oklch(0.99 0.003 265)", fg: "oklch(0.20 0.015 265)", muted: "oklch(0.46 0.03 265)", primary: "oklch(0.52 0.20 275)", secondary: "oklch(0.54 0.20 305)", tertiary: "oklch(0.49 0.13 220)" },
+    dark: { bg: "oklch(0.16 0.015 265)", fg: "oklch(0.96 0.006 265)", muted: "oklch(0.70 0.02 265)", primary: "oklch(0.66 0.19 278)", secondary: "oklch(0.68 0.19 305)", tertiary: "oklch(0.74 0.13 220)" },
     fonts: { display: "Inter", body: "Inter", mono: "JetBrains Mono" },
     signature: "fine engineering grid, glass cards, hairline node graph traced by one indigo signal",
     press: "restrained",
@@ -78,8 +79,8 @@ export const DIRECTIONS: BrandDirection[] = [
     name: "Anime / Dispatch",
     emotion: "joy · surprise",
     blurb: "Cel-shaded mascot, manga speed-lines, arcade buttons.",
-    light: { bg: "oklch(0.97 0.02 90)", fg: "oklch(0.16 0.01 30)", accent: "oklch(0.66 0.20 25)", accentAlt: "oklch(0.68 0.15 250)", muted: "oklch(0.94 0.02 90)" },
-    dark: { bg: "oklch(0.19 0.05 285)", fg: "oklch(0.96 0.02 90)", accent: "oklch(0.70 0.20 25)", accentAlt: "oklch(0.72 0.16 250)", muted: "oklch(0.26 0.05 285)" },
+    light: { bg: "oklch(0.97 0.02 90)", fg: "oklch(0.16 0.01 30)", muted: "oklch(0.44 0.03 30)", primary: "oklch(0.53 0.20 25)", secondary: "oklch(0.52 0.16 250)", tertiary: "oklch(0.70 0.16 95)" },
+    dark: { bg: "oklch(0.19 0.05 285)", fg: "oklch(0.96 0.02 90)", muted: "oklch(0.72 0.04 285)", primary: "oklch(0.70 0.20 25)", secondary: "oklch(0.72 0.16 250)", tertiary: "oklch(0.85 0.17 95)" },
     fonts: { display: "Space Grotesk", body: "Inter", mono: "JetBrains Mono" },
     signature: "a courier mascot throwing event packets with manga speed-lines + comic starbursts",
     press: "hard-stamp",
@@ -89,9 +90,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "brutalist",
     name: "Brutalist Terminal",
     emotion: "confidence · power",
-    blurb: "Exposed grid, mono system, acid accent, hard offset blocks.",
-    light: { bg: "oklch(0.96 0.005 90)", fg: "oklch(0.16 0 0)", accent: "oklch(0.88 0.22 130)", accentAlt: "oklch(0.72 0.19 130)", muted: "oklch(0.93 0.004 90)" },
-    dark: { bg: "oklch(0.14 0.008 150)", fg: "oklch(0.90 0.13 135)", accent: "oklch(0.88 0.22 130)", accentAlt: "oklch(0.72 0.19 135)", muted: "oklch(0.20 0.01 150)" },
+    blurb: "Exposed grid, mono system, acid + cyan + magenta on ink.",
+    light: { bg: "oklch(0.96 0.005 90)", fg: "oklch(0.16 0 0)", muted: "oklch(0.42 0.006 90)", primary: "oklch(0.62 0.18 135)", secondary: "oklch(0.49 0.15 235)", tertiary: "oklch(0.55 0.24 350)" },
+    dark: { bg: "oklch(0.14 0.008 150)", fg: "oklch(0.90 0.13 135)", muted: "oklch(0.62 0.09 140)", primary: "oklch(0.88 0.22 130)", secondary: "oklch(0.78 0.15 220)", tertiary: "oklch(0.72 0.24 350)" },
     fonts: { display: "Archivo", body: "Inter", mono: "Space Mono" },
     signature: "exposed grid + section numerals, ASCII-ish fan-out, hard offset blocks (no radius)",
     press: "hard-stamp",
@@ -102,8 +103,8 @@ export const DIRECTIONS: BrandDirection[] = [
     name: "Aurora / Ethereal",
     emotion: "awe · calm",
     blurb: "Drifting northern-lights behind glass. Luminous, cinematic.",
-    light: { bg: "oklch(0.97 0.012 240)", fg: "oklch(0.24 0.04 265)", accent: "oklch(0.64 0.22 300)", accentAlt: "oklch(0.80 0.15 175)", muted: "oklch(0.95 0.012 240)" },
-    dark: { bg: "oklch(0.17 0.03 260)", fg: "oklch(0.96 0.01 250)", accent: "oklch(0.70 0.24 340)", accentAlt: "oklch(0.82 0.15 175)", muted: "oklch(0.23 0.03 260)" },
+    light: { bg: "oklch(0.97 0.012 240)", fg: "oklch(0.24 0.04 265)", muted: "oklch(0.48 0.05 265)", primary: "oklch(0.55 0.20 300)", secondary: "oklch(0.49 0.13 175)", tertiary: "oklch(0.58 0.20 340)" },
+    dark: { bg: "oklch(0.17 0.03 260)", fg: "oklch(0.96 0.01 250)", muted: "oklch(0.72 0.03 260)", primary: "oklch(0.70 0.24 340)", secondary: "oklch(0.82 0.15 175)", tertiary: "oklch(0.72 0.20 300)" },
     fonts: { display: "Fraunces", body: "Inter", mono: "JetBrains Mono" },
     signature: "slow-drifting aurora blobs behind glass; a radiant core firing soft beams to nodes",
     press: "glow-inset",
@@ -114,8 +115,8 @@ export const DIRECTIONS: BrandDirection[] = [
     name: "Synthwave",
     emotion: "nostalgia · exhilaration",
     blurb: "80s neon grid to a sunset horizon. Chrome type, VHS glow.",
-    light: { bg: "oklch(0.96 0.02 320)", fg: "oklch(0.22 0.06 285)", accent: "oklch(0.66 0.28 350)", accentAlt: "oklch(0.82 0.16 200)", muted: "oklch(0.93 0.03 320)" },
-    dark: { bg: "oklch(0.18 0.06 285)", fg: "oklch(0.96 0.02 320)", accent: "oklch(0.66 0.28 350)", accentAlt: "oklch(0.82 0.16 200)", muted: "oklch(0.24 0.06 285)" },
+    light: { bg: "oklch(0.96 0.02 320)", fg: "oklch(0.22 0.06 285)", muted: "oklch(0.46 0.06 285)", primary: "oklch(0.55 0.26 350)", secondary: "oklch(0.55 0.15 210)", tertiary: "oklch(0.60 0.18 45)" },
+    dark: { bg: "oklch(0.18 0.06 285)", fg: "oklch(0.96 0.02 320)", muted: "oklch(0.72 0.05 285)", primary: "oklch(0.70 0.27 350)", secondary: "oklch(0.82 0.16 200)", tertiary: "oklch(0.75 0.18 45)" },
     fonts: { display: "Chakra Petch", body: "Inter", mono: "JetBrains Mono" },
     signature: "perspective neon grid to a glowing sunset orb; event rockets across with neon trails",
     press: "gradient-lift",
@@ -125,9 +126,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "editorial",
     name: "Editorial / Swiss",
     emotion: "sophistication · authority",
-    blurb: "Giant serif, strict grid, pull-quotes, one vermilion accent.",
-    light: { bg: "oklch(0.98 0.006 85)", fg: "oklch(0.18 0.01 60)", accent: "oklch(0.60 0.22 28)", accentAlt: "oklch(0.52 0.20 28)", muted: "oklch(0.95 0.006 85)" },
-    dark: { bg: "oklch(0.185 0.012 60)", fg: "oklch(0.95 0.01 85)", accent: "oklch(0.66 0.20 28)", accentAlt: "oklch(0.72 0.16 28)", muted: "oklch(0.24 0.012 60)" },
+    blurb: "Giant serif, strict grid, pull-quotes, vermilion + ink-blue + gold.",
+    light: { bg: "oklch(0.98 0.006 85)", fg: "oklch(0.18 0.01 60)", muted: "oklch(0.44 0.02 60)", primary: "oklch(0.55 0.21 28)", secondary: "oklch(0.42 0.10 250)", tertiary: "oklch(0.58 0.11 85)" },
+    dark: { bg: "oklch(0.185 0.012 60)", fg: "oklch(0.95 0.01 85)", muted: "oklch(0.70 0.02 60)", primary: "oklch(0.68 0.19 28)", secondary: "oklch(0.72 0.12 250)", tertiary: "oklch(0.80 0.11 85)" },
     fonts: { display: "Fraunces", body: "Archivo", mono: "JetBrains Mono" },
     signature: "strict column rules, section numerals, hanging pull-quote, hairline contents-page index",
     press: "restrained",
@@ -137,9 +138,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "kinetic",
     name: "Kinetic / Motion-first",
     emotion: "momentum · excitement",
-    blurb: "Marquee rails, live counters, everything moves. Electric yellow.",
-    light: { bg: "oklch(0.97 0.01 95)", fg: "oklch(0.15 0.01 250)", accent: "oklch(0.88 0.19 100)", accentAlt: "oklch(0.66 0.22 35)", muted: "oklch(0.94 0.01 95)" },
-    dark: { bg: "oklch(0.15 0.01 250)", fg: "oklch(0.97 0.01 95)", accent: "oklch(0.88 0.19 100)", accentAlt: "oklch(0.66 0.22 35)", muted: "oklch(0.22 0.01 250)" },
+    blurb: "Marquee rails, live counters, everything moves. Yellow + red + blue.",
+    light: { bg: "oklch(0.97 0.01 95)", fg: "oklch(0.15 0.01 250)", muted: "oklch(0.44 0.02 250)", primary: "oklch(0.53 0.18 45)", secondary: "oklch(0.50 0.15 240)", tertiary: "oklch(0.62 0.14 100)" },
+    dark: { bg: "oklch(0.15 0.01 250)", fg: "oklch(0.97 0.01 95)", muted: "oklch(0.70 0.02 250)", primary: "oklch(0.88 0.19 100)", secondary: "oklch(0.66 0.22 35)", tertiary: "oklch(0.72 0.16 240)" },
     fonts: { display: "Anton", body: "Inter", mono: "JetBrains Mono" },
     signature: "opposing marquee rails, live dispatch counter, continuously-looping fan-out",
     press: "hard-stamp",
@@ -149,9 +150,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "organic",
     name: "Organic / Living",
     emotion: "warmth · growth",
-    blurb: "Mycelial roots grow the event to platforms. Moss + clay, soft.",
-    light: { bg: "oklch(0.96 0.02 85)", fg: "oklch(0.28 0.03 120)", accent: "oklch(0.55 0.12 150)", accentAlt: "oklch(0.68 0.14 45)", muted: "oklch(0.93 0.028 82)" },
-    dark: { bg: "oklch(0.19 0.024 155)", fg: "oklch(0.94 0.02 90)", accent: "oklch(0.72 0.13 148)", accentAlt: "oklch(0.72 0.14 60)", muted: "oklch(0.25 0.024 155)" },
+    blurb: "Mycelial roots grow the event to platforms. Moss + clay + gold.",
+    light: { bg: "oklch(0.96 0.02 85)", fg: "oklch(0.26 0.03 120)", muted: "oklch(0.46 0.04 120)", primary: "oklch(0.52 0.12 150)", secondary: "oklch(0.53 0.14 45)", tertiary: "oklch(0.62 0.11 88)" },
+    dark: { bg: "oklch(0.19 0.024 155)", fg: "oklch(0.94 0.02 90)", muted: "oklch(0.70 0.03 130)", primary: "oklch(0.72 0.13 148)", secondary: "oklch(0.72 0.14 60)", tertiary: "oklch(0.82 0.12 88)" },
     fonts: { display: "Fraunces", body: "DM Sans", mono: "JetBrains Mono" },
     signature: "morphing gooey blobs; mycelial roots growing from event to nodes (draw-on)",
     press: "glow-inset",
@@ -161,9 +162,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "cyberpunk",
     name: "Cyberpunk / HUD",
     emotion: "intensity · adrenaline",
-    blurb: "Neon-noir ops console, HUD reticles, glitch, packet stream.",
-    light: { bg: "oklch(0.96 0.012 220)", fg: "oklch(0.20 0.03 220)", accent: "oklch(0.65 0.28 350)", accentAlt: "oklch(0.72 0.14 195)", muted: "oklch(0.93 0.012 220)" },
-    dark: { bg: "oklch(0.15 0.02 220)", fg: "oklch(0.92 0.03 195)", accent: "oklch(0.65 0.28 350)", accentAlt: "oklch(0.85 0.15 195)", muted: "oklch(0.21 0.02 220)" },
+    blurb: "Neon-noir ops console, HUD reticles. Magenta + cyan + amber.",
+    light: { bg: "oklch(0.96 0.012 220)", fg: "oklch(0.20 0.03 220)", muted: "oklch(0.44 0.04 220)", primary: "oklch(0.55 0.26 350)", secondary: "oklch(0.52 0.13 200)", tertiary: "oklch(0.53 0.15 75)" },
+    dark: { bg: "oklch(0.15 0.02 220)", fg: "oklch(0.92 0.03 195)", muted: "oklch(0.68 0.05 200)", primary: "oklch(0.68 0.27 350)", secondary: "oklch(0.85 0.15 195)", tertiary: "oklch(0.80 0.17 75)" },
     fonts: { display: "Chakra Petch", body: "Inter", mono: "JetBrains Mono" },
     signature: "HUD corner brackets + reticles, scan lines, glitch on a keyword, chamfered buttons",
     press: "glow-inset",
@@ -173,9 +174,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "luxury",
     name: "Luxury / Obsidian & Gold",
     emotion: "prestige · desire",
-    blurb: "Obsidian + gold, fine serif, gold-foil sheen. Infra as a luxury good.",
-    light: { bg: "oklch(0.965 0.012 84)", fg: "oklch(0.24 0.02 60)", accent: "oklch(0.60 0.13 74)", accentAlt: "oklch(0.80 0.13 85)", muted: "oklch(0.94 0.012 84)" },
-    dark: { bg: "oklch(0.16 0.008 60)", fg: "oklch(0.93 0.018 82)", accent: "oklch(0.80 0.13 85)", accentAlt: "oklch(0.86 0.10 88)", muted: "oklch(0.22 0.008 60)" },
+    blurb: "Obsidian + gold, fine serif, gold-foil sheen + deep burgundy.",
+    light: { bg: "oklch(0.965 0.012 84)", fg: "oklch(0.22 0.02 60)", muted: "oklch(0.44 0.03 60)", primary: "oklch(0.53 0.12 74)", secondary: "oklch(0.45 0.10 40)", tertiary: "oklch(0.42 0.13 20)" },
+    dark: { bg: "oklch(0.16 0.008 60)", fg: "oklch(0.93 0.018 82)", muted: "oklch(0.68 0.03 70)", primary: "oklch(0.82 0.13 85)", secondary: "oklch(0.72 0.10 55)", tertiary: "oklch(0.62 0.15 22)" },
     fonts: { display: "Cormorant Garamond", body: "Jost", mono: "JetBrains Mono" },
     signature: "thin gold hairline system, gold-foil sheen on hover, gold-line constellation, deep space",
     press: "restrained",
@@ -185,9 +186,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "clay",
     name: "Clay / Soft 3D",
     emotion: "joy · tactility",
-    blurb: "Puffy pressable clay shapes, pastel-punch, squishy buttons.",
-    light: { bg: "oklch(0.97 0.012 285)", fg: "oklch(0.24 0.03 290)", accent: "oklch(0.62 0.19 290)", accentAlt: "oklch(0.72 0.16 25)", muted: "oklch(0.94 0.012 285)" },
-    dark: { bg: "oklch(0.22 0.035 290)", fg: "oklch(0.95 0.01 290)", accent: "oklch(0.68 0.19 290)", accentAlt: "oklch(0.76 0.16 25)", muted: "oklch(0.28 0.035 290)" },
+    blurb: "Puffy pressable clay shapes. Violet + coral + mint.",
+    light: { bg: "oklch(0.97 0.012 285)", fg: "oklch(0.24 0.03 290)", muted: "oklch(0.48 0.04 290)", primary: "oklch(0.55 0.19 290)", secondary: "oklch(0.60 0.16 25)", tertiary: "oklch(0.58 0.13 165)" },
+    dark: { bg: "oklch(0.22 0.035 290)", fg: "oklch(0.95 0.01 290)", muted: "oklch(0.72 0.03 290)", primary: "oklch(0.72 0.19 290)", secondary: "oklch(0.76 0.16 25)", tertiary: "oklch(0.82 0.12 165)" },
     fonts: { display: "Fredoka", body: "DM Sans", mono: "JetBrains Mono" },
     signature: "puffy clay shapes with dual soft shadows; event orb pops out to squishy platform coins",
     press: "gradient-lift",
@@ -197,9 +198,9 @@ export const DIRECTIONS: BrandDirection[] = [
     id: "constellation",
     name: "Constellation / Starmap",
     emotion: "wonder · reach",
-    blurb: "Event = a star; platforms light up a constellation. Deep-space.",
-    light: { bg: "oklch(0.97 0.012 260)", fg: "oklch(0.26 0.04 268)", accent: "oklch(0.72 0.14 275)", accentAlt: "oklch(0.86 0.11 90)", muted: "oklch(0.94 0.012 260)" },
-    dark: { bg: "oklch(0.16 0.03 265)", fg: "oklch(0.95 0.012 250)", accent: "oklch(0.85 0.12 200)", accentAlt: "oklch(0.86 0.11 90)", muted: "oklch(0.22 0.03 265)" },
+    blurb: "Event = a star; platforms light a constellation. Periwinkle + cyan + gold.",
+    light: { bg: "oklch(0.97 0.012 260)", fg: "oklch(0.26 0.04 268)", muted: "oklch(0.48 0.05 268)", primary: "oklch(0.52 0.16 275)", secondary: "oklch(0.53 0.13 220)", tertiary: "oklch(0.60 0.12 90)" },
+    dark: { bg: "oklch(0.16 0.03 265)", fg: "oklch(0.95 0.012 250)", muted: "oklch(0.70 0.03 265)", primary: "oklch(0.72 0.14 275)", secondary: "oklch(0.85 0.12 200)", tertiary: "oklch(0.86 0.11 90)" },
     fonts: { display: "Space Grotesk", body: "Inter", mono: "JetBrains Mono" },
     signature: "animated starfield; event-star connects via drawn glowing edges to twinkling platform stars",
     press: "glow-inset",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
 import { DIRECTIONS, getDirection } from "./catalog.js";
-import { renderTokensCss, renderTokensJson, googleFontsHref } from "./tokens.js";
+import {
+  renderTokensCss,
+  renderTokensJson,
+  googleFontsHref,
+  checkContrast,
+} from "./tokens.js";
+import type { BrandDirection } from "./catalog.js";
 
 const [cmd, arg] = process.argv.slice(2);
 
@@ -34,6 +40,26 @@ switch (cmd) {
   case "fonts":
     console.log(googleFontsHref(need(arg)));
     break;
+  case "check": {
+    const targets: BrandDirection[] = arg === "--all" || arg === undefined ? DIRECTIONS : [need(arg)];
+    let failed = 0;
+    for (const d of targets) {
+      const checks = checkContrast(d);
+      const bad = checks.filter((c) => !c.pass);
+      failed += bad.length;
+      const mark = bad.length === 0 ? "PASS" : "FAIL";
+      console.log(`\n${mark}  ${d.id} — ${d.name}`);
+      for (const c of checks) {
+        console.log(`  ${c.pass ? "ok " : "XX "} ${c.ratio.toFixed(2).padStart(5)}:1  ${c.level.padEnd(8)}  ${c.pair}`);
+      }
+    }
+    if (failed > 0) {
+      console.error(`\n${failed} contrast pair(s) below WCAG AA (4.5:1).`);
+      process.exit(1);
+    }
+    console.log("\nAll pairs pass WCAG AA.");
+    break;
+  }
   case undefined:
   case "help":
   case "-h":
@@ -47,6 +73,7 @@ switch (cmd) {
         "  vibebrand tokens <id>         print the design-system CSS (custom properties)",
         "  vibebrand json <id>           print structured tokens as JSON",
         "  vibebrand fonts <id>          print the Google Fonts <link> href",
+        "  vibebrand check [id|--all]    WCAG AA contrast report (exits 1 on any fail)",
         "",
         "example:",
         "  vibebrand tokens brutalist > tokens.css",

--- a/src/contrast.ts
+++ b/src/contrast.ts
@@ -1,0 +1,85 @@
+/**
+ * WCAG contrast math for oklch colors — so every generated palette is provably
+ * accessible, not just "looks fine". Parses `oklch(L C H)`, converts through
+ * OKLab → linear sRGB → relative luminance, and returns WCAG contrast ratios.
+ */
+
+export interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Parse an `oklch(L C H)` / `oklch(L C H / A)` string. L is 0..1, H in degrees. */
+export function parseOklch(s: string): { l: number; c: number; h: number } {
+  const m = s.match(/oklch\(\s*([\d.]+%?)\s+([\d.]+)\s+([\d.]+)/i);
+  if (!m) throw new Error(`not an oklch() color: ${s}`);
+  const l = m[1].endsWith("%") ? parseFloat(m[1]) / 100 : parseFloat(m[1]);
+  return { l, c: parseFloat(m[2]), h: parseFloat(m[3]) };
+}
+
+/** OKLCH → linear-light sRGB (Björn Ottosson's matrices). Values may be <0 or >1 (out of gamut). */
+export function oklchToLinearRgb(str: string): Rgb {
+  const { l: L, c: C, h: H } = parseOklch(str);
+  const hr = (H * Math.PI) / 180;
+  const a = C * Math.cos(hr);
+  const b = C * Math.sin(hr);
+
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+
+  const l3 = l_ * l_ * l_;
+  const m3 = m_ * m_ * m_;
+  const s3 = s_ * s_ * s_;
+
+  return {
+    r: 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3,
+    g: -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3,
+    b: -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3,
+  };
+}
+
+/** WCAG relative luminance from a linear-sRGB triple (clamped to gamut). */
+export function relativeLuminance(str: string): number {
+  const { r, g, b } = oklchToLinearRgb(str);
+  const c = (x: number) => Math.min(1, Math.max(0, x));
+  return 0.2126 * c(r) + 0.7152 * c(g) + 0.0722 * c(b);
+}
+
+/** WCAG contrast ratio between two oklch colors (1..21). */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+export type WcagLevel = "AAA" | "AA" | "AA-large" | "fail";
+
+/** WCAG level for a normal-text pair (AA=4.5, AAA=7); "AA-large" (3.0) for large/UI. */
+export function wcagLevel(ratio: number): WcagLevel {
+  if (ratio >= 7) return "AAA";
+  if (ratio >= 4.5) return "AA";
+  if (ratio >= 3) return "AA-large";
+  return "fail";
+}
+
+// ponytail: self-check the color math — assert the anchors, else the whole
+// accessibility guarantee is silently wrong. Runs via `node dist/contrast.js`
+// or an import; throws on regression.
+export function _selfCheck(): void {
+  const white = "oklch(1 0 0)";
+  const black = "oklch(0 0 0)";
+  const wb = contrastRatio(white, black);
+  if (Math.abs(wb - 21) > 0.5) throw new Error(`white/black should be ~21, got ${wb.toFixed(2)}`);
+  if (contrastRatio(black, black) > 1.01) throw new Error("same color must be ~1");
+  // mid grey on white is a known ~AA-ish anchor: just assert ordering sanity
+  if (relativeLuminance(white) <= relativeLuminance(black)) throw new Error("white must be brighter than black");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  _selfCheck();
+  // eslint-disable-next-line no-console
+  console.log("contrast self-check OK");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,19 @@ export {
   renderTokensCss,
   renderTokensJson,
   googleFontsHref,
+  checkContrast,
+  pickOn,
+  type ContrastCheck,
 } from "./tokens.js";
+export {
+  contrastRatio,
+  wcagLevel,
+  relativeLuminance,
+  type WcagLevel,
+} from "./contrast.js";
 
 import { DIRECTIONS, getDirection } from "./catalog.js";
-import { renderTokensCss, renderTokensJson } from "./tokens.js";
+import { renderTokensCss, renderTokensJson, checkContrast } from "./tokens.js";
 
 /** Convenience façade over the catalog + token generators. */
 export function createVibebrand() {
@@ -34,6 +43,12 @@ export function createVibebrand() {
       const d = getDirection(id);
       if (!d) throw new Error(`unknown direction: ${id}`);
       return renderTokensJson(d);
+    },
+    /** WCAG contrast report for a direction id (light + dark). */
+    check: (id: string) => {
+      const d = getDirection(id);
+      if (!d) throw new Error(`unknown direction: ${id}`);
+      return checkContrast(d);
     },
   };
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,5 @@
 import type { BrandDirection, Palette } from "./catalog.js";
+import { contrastRatio, wcagLevel, type WcagLevel } from "./contrast.js";
 
 const RADIUS: Record<BrandDirection["radius"], string> = {
   sharp: "0",
@@ -6,14 +7,17 @@ const RADIUS: Record<BrandDirection["radius"], string> = {
   round: "1rem",
 };
 
-/** Shadow language keyed off the button press personality. */
+const INK = "oklch(0.15 0 0)";
+const PAPER = "oklch(0.98 0 0)";
+
+/** Pick the text color (near-ink or near-paper) with the best contrast on a fill. */
+export function pickOn(fill: string): string {
+  return contrastRatio(fill, INK) >= contrastRatio(fill, PAPER) ? INK : PAPER;
+}
+
 function shadowScale(d: BrandDirection): { sm: string; md: string; lg: string } {
   if (d.press === "hard-stamp") {
-    return {
-      sm: "2px 2px 0 var(--fg)",
-      md: "4px 4px 0 var(--fg)",
-      lg: "6px 6px 0 var(--fg)",
-    };
+    return { sm: "2px 2px 0 var(--fg)", md: "4px 4px 0 var(--fg)", lg: "6px 6px 0 var(--fg)" };
   }
   return {
     sm: "0 1px 2px rgba(0,0,0,0.06)",
@@ -23,25 +27,34 @@ function shadowScale(d: BrandDirection): { sm: string; md: string; lg: string } 
 }
 
 function paletteVars(p: Palette, indent = "  "): string {
-  return [
-    `${indent}--bg: ${p.bg};`,
-    `${indent}--fg: ${p.fg};`,
-    `${indent}--accent: ${p.accent};`,
-    `${indent}--accent-alt: ${p.accentAlt};`,
-    `${indent}--muted: ${p.muted};`,
-  ].join("\n");
+  const lines = [
+    `--bg: ${p.bg};`,
+    // surface + border derived so they always track bg/fg and theme correctly
+    `--surface: color-mix(in oklch, var(--bg) 92%, var(--fg));`,
+    `--border: color-mix(in oklch, var(--fg) 18%, transparent);`,
+    `--fg: ${p.fg};`,
+    `--muted: ${p.muted};`,
+    `--primary: ${p.primary};`,
+    `--secondary: ${p.secondary};`,
+    `--tertiary: ${p.tertiary};`,
+    `--on-primary: ${pickOn(p.primary)};`,
+    `--on-secondary: ${pickOn(p.secondary)};`,
+    `--on-tertiary: ${pickOn(p.tertiary)};`,
+  ];
+  return lines.map((l) => indent + l).join("\n");
 }
 
 /**
- * Render a direction to a self-contained block of CSS custom properties:
- * light palette on :root, dark palette on [data-theme="dark"] and
- * prefers-color-scheme, plus radius / shadow / font tokens.
+ * Render a direction to CSS custom properties — a 3-color system (primary /
+ * secondary / tertiary) with auto-computed accessible on-colors, surfaces,
+ * radius/shadow/font tokens; light on :root, dark on prefers-color-scheme +
+ * [data-theme="dark"].
  */
 export function renderTokensCss(d: BrandDirection): string {
   const s = shadowScale(d);
   return `/* vibebrand — ${d.name} (${d.emotion})
    ${d.blurb}
-   signature: ${d.signature} */
+   3-color system, WCAG-AA contrast-checked. signature: ${d.signature} */
 :root {
 ${paletteVars(d.light)}
 
@@ -67,6 +80,34 @@ ${paletteVars(d.dark)}
 `;
 }
 
+export interface ContrastCheck {
+  pair: string;
+  ratio: number;
+  level: WcagLevel;
+  /** AA pass for its role (normal text ≥4.5; UI/on-fill treated ≥4.5 too) */
+  pass: boolean;
+}
+
+/** The contrast pairs that must hold for a palette to be accessible. */
+function checkPalette(p: Palette, theme: string): ContrastCheck[] {
+  const pairs: [string, string, string, number][] = [
+    [`${theme}: fg on bg`, p.fg, p.bg, 4.5],
+    [`${theme}: muted on bg`, p.muted, p.bg, 4.5],
+    [`${theme}: on-primary on primary`, pickOn(p.primary), p.primary, 4.5],
+    [`${theme}: on-secondary on secondary`, pickOn(p.secondary), p.secondary, 4.5],
+    [`${theme}: on-tertiary on tertiary`, pickOn(p.tertiary), p.tertiary, 4.5],
+  ];
+  return pairs.map(([pair, a, b, min]) => {
+    const ratio = contrastRatio(a, b);
+    return { pair, ratio: Math.round(ratio * 100) / 100, level: wcagLevel(ratio), pass: ratio >= min };
+  });
+}
+
+/** Full contrast report for a direction (light + dark). */
+export function checkContrast(d: BrandDirection): ContrastCheck[] {
+  return [...checkPalette(d.light, "light"), ...checkPalette(d.dark, "dark")];
+}
+
 /** Structured token object (for JSON export / programmatic use). */
 export function renderTokensJson(d: BrandDirection) {
   return {
@@ -76,7 +117,11 @@ export function renderTokensJson(d: BrandDirection) {
     radius: RADIUS[d.radius],
     shadows: shadowScale(d),
     fonts: d.fonts,
-    color: { light: d.light, dark: d.dark },
+    color: {
+      light: { ...d.light, onPrimary: pickOn(d.light.primary), onSecondary: pickOn(d.light.secondary), onTertiary: pickOn(d.light.tertiary) },
+      dark: { ...d.dark, onPrimary: pickOn(d.dark.primary), onSecondary: pickOn(d.dark.secondary), onTertiary: pickOn(d.dark.tertiary) },
+    },
+    contrast: checkContrast(d),
   };
 }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/contrast.ts"],
   format: "esm",
   dts: true,
   clean: true,


### PR DESCRIPTION
Addresses the 'all-green is boring' feedback: every direction now ships a real **3-color system** (primary/secondary/tertiary, light + dark), and a built-in **oklch → WCAG contrast engine** guarantees accessibility.

- `contrast.ts` — oklch→OKLab→linear-sRGB→WCAG ratios (self-checked, white/black = 21.00).
- `tokens.ts` — auto-picks accessible `--on-primary/secondary/tertiary` (≥4.5:1), derives surface/border.
- `catalog.ts` — all 14 directions get 3 real brand colors (brutalist = acid + cyan + magenta), tuned to pass AA.
- `vibebrand check [id|--all]` — per-pair WCAG report, exits 1 on fail; `npm test` gates on it.

All 14 pass WCAG AA (light + dark).