### PR TITLE
vibebrand v0.2 — Tailwind @theme, SVG logo, init

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ and theme every time, commit to a *direction* and generate the foundation.
 ```bash
 npx vibebrand directions          # list the directions
 npx vibebrand tokens brutalist    # print the design-system CSS
-npx vibebrand tokens signal > tokens.css
+npx vibebrand tailwind signal     # Tailwind v4 @theme block
+npx vibebrand logo aurora         # generative brand mark (SVG)
+npx vibebrand init blueprint      # write tokens.css + tailwind.css + logo.svg into your project
 ```
 
 ## Use it as a library
@@ -56,12 +58,13 @@ npx vibebrand check --all       # exits 1 if any pair is below AA
 
 ## Roadmap
 
-- **Logo / favicon / OG generators** — emit an SVG mark, favicon set, and OG
-  image per direction.
+Shipped: Tailwind v4 `@theme` export (`tailwind`), a generative brand mark
+(`logo`), and project scaffolding (`init`). Next:
+
+- **Favicon + OG generators** — a favicon set and an OG image per direction.
 - **MCP server** (`vibebrand-mcp`) — drive the generators from any AI agent.
-- **`vibebrand init`** — scaffold tokens + logo + a `/brand` guidelines page
-  straight into a project.
-- **Framework adapters** — Tailwind v4 `@theme` export, shadcn token map.
+- **`vibebrand init` → `/brand` page** — also scaffold a live guidelines page.
+- **shadcn token map** adapter; publish to npm.
 
 Part of the [getvibe.dev](https://getvibe.dev) family.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+
 import { DIRECTIONS, getDirection } from "./catalog.js";
 import {
   renderTokensCss,
@@ -6,9 +8,14 @@ import {
   googleFontsHref,
   checkContrast,
 } from "./tokens.js";
+import {
+  renderLogoSvg,
+  renderTailwindTheme,
+  renderInitFiles,
+} from "./generators.js";
 import type { BrandDirection } from "./catalog.js";
 
-const [cmd, arg] = process.argv.slice(2);
+const [cmd, arg, arg2] = process.argv.slice(2);
 
 function listDirections() {
   const w = Math.max(...DIRECTIONS.map((d) => d.id.length));
@@ -40,6 +47,22 @@ switch (cmd) {
   case "fonts":
     console.log(googleFontsHref(need(arg)));
     break;
+  case "logo":
+    process.stdout.write(renderLogoSvg(need(arg), arg2 === "dark" ? "dark" : "light") + "\n");
+    break;
+  case "tailwind":
+    process.stdout.write(renderTailwindTheme(need(arg)) + "\n");
+    break;
+  case "init": {
+    const d = arg ? need(arg) : DIRECTIONS[0];
+    const files = renderInitFiles(d, renderTokensCss(d));
+    for (const [name, contents] of Object.entries(files)) {
+      writeFileSync(name, contents);
+      console.log(`wrote ${name}`);
+    }
+    console.log(`\nInitialized the "${d.name}" brand system. Import vibebrand-tokens.css and go.`);
+    break;
+  }
   case "check": {
     const targets: BrandDirection[] = arg === "--all" || arg === undefined ? DIRECTIONS : [need(arg)];
     let failed = 0;
@@ -74,6 +97,9 @@ switch (cmd) {
         "  vibebrand json <id>           print structured tokens as JSON",
         "  vibebrand fonts <id>          print the Google Fonts <link> href",
         "  vibebrand check [id|--all]    WCAG AA contrast report (exits 1 on any fail)",
+        "  vibebrand logo <id> [dark]    print the generative brand mark as SVG",
+        "  vibebrand tailwind <id>       print a Tailwind v4 @theme block",
+        "  vibebrand init [id]           write tokens.css + tailwind.css + logo.svg into cwd",
         "",
         "example:",
         "  vibebrand tokens brutalist > tokens.css",

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -1,0 +1,61 @@
+import type { BrandDirection, Palette } from "./catalog.js";
+import { pickOn } from "./tokens.js";
+
+const RADIUS_PX: Record<BrandDirection["radius"], number> = { sharp: 0, soft: 6, round: 12 };
+
+/**
+ * A generative brand mark: three offset squares in the direction's three brand
+ * colors — a literal glyph for the 3-color system — with the direction's corner
+ * radius. Square, legible at 16px, themeable. A real starting point, not final art.
+ */
+export function renderLogoSvg(d: BrandDirection, theme: "light" | "dark" = "light"): string {
+  const p: Palette = d[theme];
+  const r = RADIUS_PX[d.radius];
+  const sq = (x: number, y: number, fill: string) =>
+    `<rect x="${x}" y="${y}" width="20" height="20" rx="${r}" fill="${fill}"/>`;
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="${d.name} mark">
+  ${sq(2, 2, p.tertiary)}
+  ${sq(6, 6, p.secondary)}
+  ${sq(10, 10, p.primary)}
+</svg>`;
+}
+
+/** Primary lockup as inline SVG: mark + wordmark. */
+export function renderLockupSvg(d: BrandDirection, name: string, theme: "light" | "dark" = "light"): string {
+  const p = d[theme];
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 32" role="img" aria-label="${name}">
+  ${renderLogoSvg(d, theme).replace(/^<svg[^>]*>|<\/svg>$/g, "").trim()}
+  <text x="40" y="22" font-family="${d.fonts.display}, sans-serif" font-size="20" font-weight="700" fill="${p.fg}">${name}</text>
+</svg>`;
+}
+
+/** Tailwind v4 `@theme` block mapping the direction's tokens to Tailwind color/radius vars. */
+export function renderTailwindTheme(d: BrandDirection): string {
+  const p = d.light;
+  return `/* vibebrand — ${d.name}: Tailwind v4 @theme (light; wrap the dark values in a dark variant) */
+@theme {
+  --color-bg: ${p.bg};
+  --color-fg: ${p.fg};
+  --color-muted: ${p.muted};
+  --color-primary: ${p.primary};
+  --color-on-primary: ${pickOn(p.primary)};
+  --color-secondary: ${p.secondary};
+  --color-on-secondary: ${pickOn(p.secondary)};
+  --color-tertiary: ${p.tertiary};
+  --color-on-tertiary: ${pickOn(p.tertiary)};
+  --radius: ${RADIUS_PX[d.radius] / 16}rem;
+  --font-display: "${d.fonts.display}", sans-serif;
+  --font-body: "${d.fonts.body}", sans-serif;
+  --font-mono: "${d.fonts.mono}", monospace;
+}`;
+}
+
+/** The files `vibebrand init` writes into a project, as {filename: contents}. */
+export function renderInitFiles(d: BrandDirection, cssFromTokens: string): Record<string, string> {
+  return {
+    "vibebrand-tokens.css": cssFromTokens,
+    "vibebrand-tailwind.css": renderTailwindTheme(d),
+    "vibebrand-logo.svg": renderLogoSvg(d, "light"),
+    "vibebrand-logo-dark.svg": renderLogoSvg(d, "dark"),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,12 @@ export {
   relativeLuminance,
   type WcagLevel,
 } from "./contrast.js";
+export {
+  renderLogoSvg,
+  renderLockupSvg,
+  renderTailwindTheme,
+  renderInitFiles,
+} from "./generators.js";
 
 import { DIRECTIONS, getDirection } from "./catalog.js";
 import { renderTokensCss, renderTokensJson, checkContrast } from "./tokens.js";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/cli.ts", "src/contrast.ts"],
+  entry: ["src/index.ts", "src/cli.ts", "src/contrast.ts", "src/generators.ts"],
   format: "esm",
   dts: true,
   clean: true,


### PR DESCRIPTION
Roadmap increment:
- `vibebrand tailwind <id>` — Tailwind v4 `@theme` block
- `vibebrand logo <id> [dark]` — generative brand mark (3 offset squares in the direction's brand colors, radius per direction)
- `vibebrand init [id]` — scaffolds `vibebrand-tokens.css` + `vibebrand-tailwind.css` + `vibebrand-logo.svg`/`-dark.svg` into a project
- SDK exports `renderTailwindTheme`/`renderLogoSvg`/`renderLockupSvg`/`renderInitFiles`

Builds clean; all 14 still pass WCAG AA (`npm test`). Next: favicon+OG generators, MCP server, npm publish.