### PR TITLE
Add mascot parametric variety

### DIFF
--- a/mascot/bat.avatar.json
+++ b/mascot/bat.avatar.json
@@ -68,6 +68,21 @@
     "wink": {
       "eyeL": { "type": "path", "d": "M211 246 q13 11 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
       "hiL": { "fill": null }
+    },
+    "excited": {
+      "eyeL": { "rx": 13.5, "ry": 16 },
+      "eyeR": { "rx": 13.5, "ry": 16 },
+      "mouth": { "type": "ellipse", "cx": 259, "cy": 298, "rx": 13, "ry": 11, "fill": "membrane", "stroke": null, "strokeWidth": null, "d": null }
+    },
+    "sad": {
+      "eyeL": { "type": "path", "d": "M211 252 q13 -11 26 -6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
+      "eyeR": { "type": "path", "d": "M281 240 q13 -7 26 6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
+      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "mouth": { "d": "M244 302 Q259 288 274 302" }
+    },
+    "skeptical": {
+      "eyeR": { "ry": 6.5 },
+      "mouth": { "d": "M247 296 H271" }
     }
   },
   "accessories": {

--- a/mascot/branding-pack.mjs
+++ b/mascot/branding-pack.mjs
@@ -1,0 +1,95 @@
+// vibebrand · branding-pack builder
+// Emit a full brand asset pack from one .avatar.json spec.
+//   node mascot/branding-pack.mjs <spec.avatar.json> <outDir> ["Display Name" "Tagline"]
+//
+// Everything is SVG (resolution-independent). Rasterize to PNG downstream where a
+// platform requires it (favicon PNGs, social uploads).
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { renderTile, renderAvatar } from "./engine.js";
+
+const [, , specPath, outDir = ".", nameArg, tagArg] = process.argv;
+if (!specPath) { console.error("usage: branding-pack.mjs <spec> <outDir> [name] [tagline]"); process.exit(1); }
+const spec = JSON.parse(readFileSync(specPath, "utf8"));
+mkdirSync(outDir, { recursive: true });
+const P = spec.palette;
+const field = P.field, ink = P.ink || "#161616";
+const title = nameArg || spec.name;
+const tagline = tagArg || "";
+
+// the character with no field, as an inner <g> we can place onto any canvas
+const glyph = (size) => renderAvatar(spec, { size, showField: false }).replace(/^<svg[^>]*>|<\/svg>$/g, "");
+const [, , VW, VH] = spec.viewBox;
+
+// place the 0..VW glyph into a w×h canvas at (x,y) scaled to `gh` tall
+function place(gh, x, y) {
+  const s = gh / VH;
+  return `<g transform="translate(${x} ${y}) scale(${s})">${glyph(gh)}</g>`;
+}
+function textBlock(x, y, big, small, colBig, colSmall) {
+  const t = big ? `<text x="${x}" y="${y}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${big.size}" font-weight="800" fill="${colBig}" letter-spacing="-1">${big.t}</text>` : "";
+  const s = small ? `<text x="${x}" y="${y + (big ? big.size * 0.8 : 0)}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${small.size}" font-weight="500" fill="${colSmall}">${small.t}</text>` : "";
+  return t + s;
+}
+const svg = (w, h, inner) => `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">${inner}</svg>\n`;
+const onWhite = c => "#ffffff";
+const write = (name, s) => { writeFileSync(`${outDir}/${name}`, s); console.log("  ", name); };
+
+console.log(`${title} → ${outDir}`);
+
+// --- icons / favicons ---
+write("favicon.svg", renderTile(spec, { size: 64, shape: "round" }));
+write("icon-512.svg", renderTile(spec, { size: 512, shape: "round" }));
+write("icon-maskable-512.svg", svg(512, 512,
+  `<rect width="512" height="512" fill="${field}"/>` + `<g transform="translate(51.2 51.2) scale(0.8)">${renderTile(spec, { size: 512, shape: "round", bg: field }).replace(/^<svg[^>]*>|<\/svg>$/g, "")}</g>`));
+write("apple-touch-180.svg", renderTile(spec, { size: 180, shape: "round" }));
+
+// --- logo / mark ---
+write("logo-on-brand.svg", renderAvatar(spec, { size: 512 }));            // character on brand field
+write("mark-transparent.svg", renderAvatar(spec, { size: 512, showField: false })); // raw character, no bg
+write("mark-outline.svg", renderAvatar(spec, { size: 512, showField: false, outline: field })); // safe on any page
+
+// --- profile pictures (square, 1:1) ---
+write("profile-512.svg", renderTile(spec, { size: 512, shape: "round" }));
+write("profile-square-512.svg", svg(512, 512, `<rect width="512" height="512" fill="${field}"/>${place(512, 40, 24)}`));
+
+// --- Open Graph 1200×630 ---
+write("og-1200x630.svg", svg(1200, 630,
+  `<rect width="1200" height="630" fill="${field}"/>` +
+  place(430, 96, 100) +
+  textBlock(560, 300, { t: title, size: 84 }, tagline ? { t: tagline, size: 34 } : null, onWhite(), "rgba(255,255,255,.82)")));
+
+// --- LinkedIn cover 1584×396 ---
+write("linkedin-cover-1584x396.svg", svg(1584, 396,
+  `<rect width="1584" height="396" fill="${field}"/>` +
+  place(320, 120, 40) +
+  textBlock(500, 190, { t: title, size: 66 }, tagline ? { t: tagline, size: 30 } : null, onWhite(), "rgba(255,255,255,.82)")));
+
+// --- X / Twitter header 1500×500 ---
+write("x-header-1500x500.svg", svg(1500, 500,
+  `<rect width="1500" height="500" fill="${field}"/>` +
+  place(360, 150, 70) +
+  textBlock(560, 250, { t: title, size: 72 }, tagline ? { t: tagline, size: 32 } : null, onWhite(), "rgba(255,255,255,.82)")));
+
+// --- pack README ---
+write("README.md",
+`# ${title} — brand assets
+
+Generated from \`${spec.name}.avatar.json\` by vibebrand's mascot engine. All SVG
+(scalable). Rasterize to PNG where a platform needs it.
+
+| File | Use |
+|------|-----|
+| \`favicon.svg\`, \`apple-touch-180.svg\` | site favicon / iOS home-screen |
+| \`icon-512.svg\`, \`icon-maskable-512.svg\` | PWA manifest icons |
+| \`logo-on-brand.svg\` | logo on the brand field |
+| \`mark-transparent.svg\` | character alone, no background (overlays) |
+| \`mark-outline.svg\` | character with a brand outline — safe on any page, light or dark |
+| \`profile-512.svg\`, \`profile-square-512.svg\` | social profile pictures |
+| \`og-1200x630.svg\` | Open Graph / link preview |
+| \`linkedin-cover-1584x396.svg\` | LinkedIn cover |
+| \`x-header-1500x500.svg\` | X / Twitter header |
+
+Brand field \`${field}\`. Regenerate: \`node vibebrand/mascot/branding-pack.mjs ${spec.name}.avatar.json <out> "${title}" "${tagline}"\`
+`);
+
+console.log("done");

--- a/mascot/chameleon.avatar.json
+++ b/mascot/chameleon.avatar.json
@@ -52,6 +52,21 @@
     "wink": {
       "eyeL": { "type": "path", "d": "M188 252 q18 12 36 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
       "hiL": { "fill": null }
+    },
+    "excited": {
+      "eyeL": { "r": 15 },
+      "eyeR": { "r": 15 },
+      "mouth": { "type": "ellipse", "cx": 256, "cy": 322, "rx": 17, "ry": 14, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+    },
+    "sad": {
+      "eyeL": { "type": "path", "d": "M188 258 q18 -13 36 -6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
+      "eyeR": { "type": "path", "d": "M290 244 q18 -7 36 6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
+      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "mouth": { "d": "M214 328 Q256 300 298 328" }
+    },
+    "skeptical": {
+      "eyeR": { "r": 6 },
+      "mouth": { "d": "M232 322 H280" }
     }
   },
   "accessories": {},

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -95,8 +95,13 @@ function outlineLayer(parts, pal, focus, colorHex, amount = 0.045) {
 }
 
 // ---- avatar -----------------------------------------------------------------
+// opts beyond the spec: expression, accessory, field, size, outline, showField,
+//   headTurn (-1..1) — shift ONLY the non-silhouette feature parts (eyes, nose,
+//     mouth, highlights…) ±18px on x, so the head reads as glancing sideways;
+//   flip (bool) — mirror the whole character horizontally about the viewBox
+//     center (wraps the tilt group in scale(-1,1)). Both default to no-ops.
 export function renderAvatar(spec, opts = {}) {
-  const { expression, accessory, field = "field", size = 240, outline = null, showField = true } = opts;
+  const { expression, accessory, field = "field", size = 240, outline = null, showField = true, headTurn = 0, flip = false } = opts;
   const pal = { ...spec.palette, field: spec.palette[field] || spec.palette.field };
   const [x0, y0, w, h] = spec.viewBox;
   const vb = spec.viewBox.join(" ");
@@ -106,11 +111,16 @@ export function renderAvatar(spec, opts = {}) {
   const acc = (spec.accessories?.[accessory] || []).map(p => renderPart(p, pal)).join("");
   const back = showField && fieldPart ? renderPart(fieldPart, pal) : "";
   const ol = outline ? outlineLayer(rest, pal, spec.focus, outline) : "";
-  const body = rest.map(p => renderPart(p, pal)).join("");
+  const dx = Math.round(Math.max(-1, Math.min(1, +headTurn || 0)) * 18 * 100) / 100;
+  const body = rest.map(p => {
+    const el = renderPart(p, pal);
+    return dx && !p.silhouette ? `<g transform="translate(${esc(dx)} 0)">${el}</g>` : el;
+  }).join("");
   const tilt = spec.tilt
     ? `<g transform="rotate(${spec.tilt} ${spec.focus?.cx ?? x0 + w / 2} ${spec.focus?.cy ?? y0 + h / 2})">${ol}${body}${acc}</g>`
     : `${ol}${body}${acc}`;
-  return `<svg width="${size}" height="${size}" viewBox="${vb}" xmlns="http://www.w3.org/2000/svg">${back}${tilt}</svg>`;
+  const char = flip ? `<g transform="translate(${esc(2 * x0 + w)} 0) scale(-1 1)">${tilt}</g>` : tilt;
+  return `<svg width="${size}" height="${size}" viewBox="${vb}" xmlns="http://www.w3.org/2000/svg">${back}${char}</svg>`;
 }
 
 // ---- favicon / app tile: SAME geometry, framed on the head, clipped ---------

--- a/mascot/rabbit.avatar.json
+++ b/mascot/rabbit.avatar.json
@@ -43,6 +43,20 @@
     },
     "wink": {
       "eyeL": { "type": "path", "d": "M202 278 q14 13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null }
+    },
+    "excited": {
+      "eyeL": { "rx": 17.5, "ry": 26 },
+      "eyeR": { "rx": 17.5, "ry": 26 },
+      "mouth": { "type": "ellipse", "cx": 272, "cy": 322, "rx": 15, "ry": 12, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+    },
+    "sad": {
+      "eyeL": { "type": "path", "d": "M203 281 q13 -13 26 -6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
+      "eyeR": { "type": "path", "d": "M313 275 q13 -7 26 6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
+      "mouth": { "d": "M256 330 Q272 313 288 330" }
+    },
+    "skeptical": {
+      "eyeR": { "ry": 12 },
+      "mouth": { "d": "M258 324 H286" }
     }
   },
   "accessories": {

--- a/mascot/sheep.avatar.json
+++ b/mascot/sheep.avatar.json
@@ -51,6 +51,21 @@
     "wink": {
       "eyeL": { "type": "path", "d": "M226 302 q14 13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
       "hiL": { "fill": null }
+    },
+    "excited": {
+      "eyeL": { "rx": 19, "ry": 24 },
+      "eyeR": { "rx": 19, "ry": 24 },
+      "mouth": { "type": "ellipse", "cx": 278, "cy": 334, "rx": 14, "ry": 12, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+    },
+    "sad": {
+      "eyeL": { "type": "path", "d": "M226 306 q14 -13 28 -6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
+      "eyeR": { "type": "path", "d": "M312 294 q14 -7 28 6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
+      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "mouth": { "d": "M264 342 Q278 326 292 342" }
+    },
+    "skeptical": {
+      "eyeR": { "ry": 10.5 },
+      "mouth": { "d": "M266 336 H290" }
     }
   },
   "accessories": {


### PR DESCRIPTION
From a fleet worker (kimi-k3), reviewed + verified in the lab.

- **engine**: `headTurn` (glance left/right by offsetting feature parts, clamped) + `flip` (mirror), both backward-compatible
- **+3 expressions** per animal — excited / sad / skeptical (data-only overrides, existing ones untouched)
- also lands `branding-pack.mjs` (full social/favicon asset generator)

Verified: all 4 specs render via build.mjs with no error; new expressions appear in the lab; default output unchanged.