### PR TITLE
Ratchet clean oxlint rules to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,19 +1,98 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "import", "unicorn", "oxc"],
-  "categories": { "correctness": "warn", "suspicious": "warn", "perf": "warn", "pedantic": "off", "style": "off", "restriction": "off", "nursery": "off" },
+  "plugins": [
+    "typescript",
+    "import",
+    "unicorn",
+    "oxc"
+  ],
+  "categories": {
+    "correctness": "warn",
+    "suspicious": "warn",
+    "perf": "warn",
+    "pedantic": "off",
+    "style": "off",
+    "restriction": "off",
+    "nursery": "off"
+  },
   "rules": {
-    "complexity": ["warn", { "max": 10 }],
-    "max-lines": ["warn", { "max": 300, "skipBlankLines": true, "skipComments": true }],
-    "max-lines-per-function": ["warn", { "max": 50, "skipBlankLines": true, "skipComments": true }],
-    "max-params": ["warn", { "max": 4 }],
-    "max-depth": ["warn", { "max": 4 }],
-    "max-nested-callbacks": ["warn", { "max": 4 }],
-    "no-var": "warn", "prefer-const": "warn", "eqeqeq": "warn", "no-debugger": "warn",
-    "typescript/no-explicit-any": "warn", "typescript/no-non-null-assertion": "warn", "import/no-cycle": "warn"
+    "complexity": [
+      "warn",
+      {
+        "max": 10
+      }
+    ],
+    "max-lines": [
+      "error",
+      {
+        "max": 300,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-lines-per-function": [
+      "error",
+      {
+        "max": 50,
+        "skipBlankLines": true,
+        "skipComments": true
+      }
+    ],
+    "max-params": [
+      "warn",
+      {
+        "max": 4
+      }
+    ],
+    "max-depth": [
+      "error",
+      {
+        "max": 4
+      }
+    ],
+    "max-nested-callbacks": [
+      "error",
+      {
+        "max": 4
+      }
+    ],
+    "no-var": "error",
+    "prefer-const": "error",
+    "eqeqeq": "warn",
+    "no-debugger": "error",
+    "typescript/no-explicit-any": "error",
+    "typescript/no-non-null-assertion": "error",
+    "import/no-cycle": "error"
   },
   "overrides": [
-    { "files": ["**/*.test.ts","**/*.test.tsx","**/*.spec.ts","**/*.spec.tsx","**/__tests__/**"], "rules": { "complexity":"off","max-lines":"off","max-lines-per-function":"off","max-depth":"off","max-nested-callbacks":"off","typescript/no-explicit-any":"off","typescript/no-non-null-assertion":"off" } },
-    { "files": ["scripts/**","**/scripts/**","**/*.config.*"], "rules": { "max-lines-per-function":"off","complexity":"off" } }
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/__tests__/**"
+      ],
+      "rules": {
+        "complexity": "off",
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "max-depth": "off",
+        "max-nested-callbacks": "off",
+        "typescript/no-explicit-any": "off",
+        "typescript/no-non-null-assertion": "off"
+      }
+    },
+    {
+      "files": [
+        "scripts/**",
+        "**/scripts/**",
+        "**/*.config.*"
+      ],
+      "rules": {
+        "max-lines-per-function": "off",
+        "complexity": "off"
+      }
+    }
   ]
 }


### PR DESCRIPTION
Promotes the budget rules that currently have **zero** violations from warn to error, so any regression blocks. Violated rules stay warn for later burndown. Parse errors: 0. Small, reviewable ratchet step.