### PR TITLE
Add a seeded roster to the mascot engine

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+# The unit suite had no way to run: `test:unit` was not wired into `test`, and no
+# workflow ran tests at all. A regression in the mascot engine would have shipped
+# green. Typecheck runs here too, for the same reason.
+name: test
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Unit tests
+        run: bun run test:unit
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Build
+        run: bun run build

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Call `renderRoster(spec, seeds)` with your entity names:
 import { renderRoster } from "vibebrand/mascot/engine.js";
 import spec from "./rabbit.avatar.json" assert { type: "json" };
 
-const { svg } = renderRoster(spec, ["alice", "bob", "carol"]);
+const roster = renderRoster(spec, ["alice", "bob", "carol"]);
 // → [{ seed: "alice", svg: "<svg>…</svg>" }, …]
 ```
 
@@ -98,7 +98,7 @@ returns a new spec you can inspect, test, or render with any engine function.
 
 Full method — shape language, the three-quarter turn, light/dark, why you draw
 it once, and why the face is held constant — is in
-[`docs/mascot-system.md`](docs/mascot-system.md)."}]
+[`docs/mascot-system.md`](docs/mascot-system.md).
 
 ## The directions
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,34 @@ free: `mascot/rabbit.avatar.json` (Content Rabbit), `bat.avatar.json` (BlogBat),
 and `sheep.avatar.json` (Supportsheep) are the same 200-line engine, three
 characters. Open `mascot/brand-lab.html` to explore any of them live.
 
+### Roster: one spec, N distinct variants
+
+Any product with many named entities — agents, team members, workspaces, tenants —
+needs each entity to look distinct but obviously the same character. The roster
+system derives N deterministic variants from one spec without hand-authoring N
+avatar files.
+
+Call `renderRoster(spec, seeds)` with your entity names:
+
+```js
+import { renderRoster } from "vibebrand/mascot/engine.js";
+import spec from "./rabbit.avatar.json" assert { type: "json" };
+
+const { svg } = renderRoster(spec, ["alice", "bob", "carol"]);
+// → [{ seed: "alice", svg: "<svg>…</svg>" }, …]
+```
+
+Each variant gets a stable hue rotation (from a fixed enumerable set — the brand
+palette never grows arbitrarily) and independent silhouette jitter. The face is
+held constant: every entity shares the same eyes, nose, and mouth. A
+500-person roster still uses **N colours**, not 500.
+
+The per-seed variation is also usable directly: `variantSpec(spec, "alice")`
+returns a new spec you can inspect, test, or render with any engine function.
+
 Full method — shape language, the three-quarter turn, light/dark, why you draw
-it once — is in [`docs/mascot-system.md`](docs/mascot-system.md).
+it once, and why the face is held constant — is in
+[`docs/mascot-system.md`](docs/mascot-system.md)."}]
 
 ## The directions
 

--- a/docs/mascot-system.md
+++ b/docs/mascot-system.md
@@ -149,3 +149,39 @@ renderIdle(spec, { size: 160 });                         // ambient animation
 `mascot/rabbit.avatar.json` is the reference spec. To brand a new project, copy
 it, swap the `palette`, and reshape the silhouette parts for the animal — the
 rest of the system comes along for free.
+
+## Roster: why the face is held constant
+
+When you give every agent, team member, or workspace their own variant of the same
+character, keeping the **face unchanged** is the rule that makes the roster look
+like one family instead of N unrelated species.
+
+The face — eyes, nose, mouth — is the part a viewer reads to recognise the
+character. Move the eyes and the rabbit stops being *the* rabbit; it becomes a
+different rabbit. So the engine pins every part that does not have
+`silhouette: true` to the original geometry. Across every variant, Alice's rabbit
+and Bob's rabbit share the same eyes, the same nose, the same mouth — and the
+same expression system works identically on both.
+
+What *does* vary:
+
+- **Colour.** A hue offset from a **fixed, enumerable set** is applied to every
+  palette entry except `ink`. The set is defined (default: ten rotations from 0°
+  to 324° in 36° steps), so a brand's palette never accumulates unbounded new
+  colours. A 500-workspace roster still fits the same swatch book.
+- **Silhouette geometry.** Parts marked `silhouette: true` (ears, head, body) get
+  a per-property, per-part jitter on `cx`, `cy`, `rx`, `ry`. The jitter is seeded
+  on each part's `id` plus the property name, so every entity's silhouette is
+  stable and unique, but the overall shape-family is unchanged.
+
+The result reads as one character seen through a slightly different lens each time
+— recognisably the same rabbit, but never a carbon copy.
+
+```js
+import { renderRoster, renderAvatar } from "vibebrand/mascot/engine.js";
+import spec from "./rabbit.avatar.json" assert { type: "json" };
+
+renderRoster(spec, ["alice", "bob", "carol"])
+// → three SVGs, each with a different body colour and silhouette,
+//   all sharing the same face and expression system
+```

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -357,19 +357,28 @@ function jitterSilhouettes(parts, seed, jitter) {
   });
 }
 
+// Config mistakes raise here rather than rendering something subtly wrong:
+// an empty or NaN-bearing hue set silently produced greyscale, and a
+// non-finite jitter put NaN straight into cx/cy/rx/ry.
+//
+// jitter is a PROPORTION of each part's own value, so [0, 1) is its meaningful
+// range, not merely a safe one: at 1 a part can collapse to zero size, and a
+// large-but-finite value overflows p[prop] * (1 + offset) to Infinity.
+function assertRosterOpts(hues, jitter) {
+  if (!Array.isArray(hues) || hues.length === 0 || !hues.every(Number.isFinite)) {
+    throw new TypeError("variantSpec: `hues` must be a non-empty array of finite degree offsets");
+  }
+  if (!Number.isFinite(jitter) || jitter < 0 || jitter >= 1) {
+    throw new RangeError("variantSpec: `jitter` must be a finite number in [0, 1)");
+  }
+}
+
 export function variantSpec(spec, seed, opts = {}) {
   const { jitter = 0.06, hues = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324] } = opts;
   // Fail loudly on an empty set. Left alone, hueOff is undefined, rotateHex
   // rotates by NaN, and every variant comes out greyscale — a silent, puzzling
   // wrong result from what is plainly a config mistake.
-  if (!Array.isArray(hues) || hues.length === 0 || !hues.every(Number.isFinite)) {
-    throw new TypeError("variantSpec: `hues` must be a non-empty array of finite degree offsets");
-  }
-  // Same reason: a non-finite jitter propagates NaN into cx/cy/rx/ry and lands
-  // malformed geometry in the SVG instead of raising.
-  if (!Number.isFinite(jitter)) {
-    throw new TypeError("variantSpec: `jitter` must be a finite number");
-  }
+  assertRosterOpts(hues, jitter);
   // ONE hue offset per seed, drawn from the fixed enum.
   const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];
   const palette = rotatePalette(spec.palette, hueOff);

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -244,5 +244,119 @@ export function renderIdle(spec, opts = {}) {
     `<style>${css}</style>` + paintField(fieldPart, pal) + withTilt(spec, box, body));
 }
 
+// ---- seeded roster (deterministic variants from one spec) ------------------
+
+// FNV-1a 32-bit — fast, portable, deterministic across runtimes.
+function fnv1a(str) {
+  let h = 0x811c9dc5 >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+// Deterministic float in [0, 1) from a seed + key pair. Same inputs always
+// give the same output on any runtime.
+export function seededTrait(seed, key) {
+  return fnv1a(String(seed) + "|" + String(key)) / 0x100000000;
+}
+
+// colour helpers for variantSpec — hex ↔ HSL ↔ rotate
+function hexToRgb(hex) {
+  const v = parseInt(hex.slice(1), 16);
+  return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
+}
+function rgbToHsl(r, g, b) {
+  r /= 255; g /= 255; b /= 255;
+  const mx = Math.max(r, g, b), mn = Math.min(r, g, b);
+  let h = 0, s = 0, l = (mx + mn) / 2;
+  if (mx !== mn) {
+    const d = mx - mn;
+    s = l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
+    if (mx === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (mx === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+  }
+  return { h: h * 360, s: s * 100, l: l * 100 };
+}
+function hslToRgbStr({ h, s, l }) {
+  h /= 360; s /= 100; l /= 100;
+  if (s === 0) {
+    const g = Math.round(l * 255);
+    return "#" + [g, g, g].map(v => v.toString(16).padStart(2, "0")).join("");
+  }
+  const hue2rgb = (p, q, t) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const r = Math.round(hue2rgb(p, q, h + 1 / 3) * 255);
+  const g = Math.round(hue2rgb(p, q, h) * 255);
+  const b = Math.round(hue2rgb(p, q, h - 1 / 3) * 255);
+  return "#" + [r, g, b].map(v => v.toString(16).padStart(2, "0")).join("");
+}
+function rotateHex(hex, degrees) {
+  if (!hex || hex === "none" || !hex.startsWith("#")) return hex;
+  const { r, g, b } = hexToRgb(hex);
+  const hsl = rgbToHsl(r, g, b);
+  hsl.h = ((hsl.h + degrees) % 360 + 360) % 360;
+  return hslToRgbStr(hsl);
+}
+
+// Build a new spec (never mutates the input) with deterministic variations
+// keyed on `seed`. Colour hues rotate from a fixed, enumerable set. Silhouette
+// geometry jitters independently per part property. Face parts pass through
+// untouched — that keeps the roster one character.
+export function variantSpec(spec, seed, opts = {}) {
+  const { jitter = 0.06, hues = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324] } = opts;
+  // pick ONE hue offset from the enum for this seed
+  const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];
+
+  // deep-clone parts (face = without silhouette:true)
+  const parts = spec.parts.map(p => ({ ...p }));
+
+  // rotate palette — never touch ink
+  const palette = {};
+  for (const [k, v] of Object.entries(spec.palette)) {
+    palette[k] = k === "ink" ? v : rotateHex(v, hueOff);
+  }
+
+  // jitter silhouette geometry independently per part per property
+  for (const p of parts) {
+    if (!p.silhouette) continue;
+    for (const prop of ["rx", "ry", "cx", "cy"]) {
+      if (p[prop] === undefined) continue;
+      const t = seededTrait(seed, p.id + "|" + prop);
+      const offset = (t * 2 - 1) * jitter;
+      p[prop] = p[prop] * (1 + offset);
+    }
+  }
+
+  // Spread rather than enumerate. Listing fields by hand means any spec key
+  // added later — a new animation block, metadata, anything — is silently
+  // dropped from every variant, which would surface as a missing feature on
+  // rosters only, long after the field was added.
+  return {
+    ...spec,
+    focus: spec.focus ? { ...spec.focus } : undefined,
+    palette,
+    parts,
+  };
+}
+
+// Render a roster of variants — one per seed.
+export function renderRoster(spec, seeds, opts = {}) {
+  return seeds.map(seed => ({
+    seed,
+    svg: renderAvatar(variantSpec(spec, seed, opts), opts)
+  }));
+}
+
 // Convenience for Node consumers: everything in one namespace.
-export default { renderPart, renderAvatar, renderTile, renderIdle, expressionNames };
+export default { renderPart, renderAvatar, renderTile, renderIdle, expressionNames, seededTrait, variantSpec, renderRoster };

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -263,12 +263,21 @@ export function seededTrait(seed, key) {
 }
 
 // colour helpers for variantSpec — hex ↔ HSL ↔ rotate
+// Accepts #rgb, #rgba, #rrggbb and #rrggbbaa. Alpha is dropped, since the
+// output is opaque hex either way.
+//
+// The shorthand expansion is load-bearing: parseInt("fff", 16) reads as 0x000fff,
+// so #fff would rotate as rgb(0, 15, 255) instead of staying white. The 8-digit
+// case matters for the same reason plus one worse — folding alpha into the RGB
+// bits can flip the sign of `>> 16`. Both are silently wrong colours from a
+// perfectly valid palette.
 function hexToRgb(hex) {
-  // Expand #abc to #aabbcc first. Without this, parseInt("fff", 16) reads as
-  // 0x000fff, so #fff would rotate as rgb(0, 15, 255) instead of white — wrong
-  // colours from a perfectly valid palette, even at hue offset 0.
   let h = hex.slice(1);
-  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  if (h.length === 3 || h.length === 4) {
+    h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  } else {
+    h = h.slice(0, 6);
+  }
   const v = parseInt(h, 16);
   return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
 }
@@ -353,8 +362,13 @@ export function variantSpec(spec, seed, opts = {}) {
   // Fail loudly on an empty set. Left alone, hueOff is undefined, rotateHex
   // rotates by NaN, and every variant comes out greyscale — a silent, puzzling
   // wrong result from what is plainly a config mistake.
-  if (!Array.isArray(hues) || hues.length === 0) {
-    throw new TypeError("variantSpec: `hues` must be a non-empty array of degree offsets");
+  if (!Array.isArray(hues) || hues.length === 0 || !hues.every(Number.isFinite)) {
+    throw new TypeError("variantSpec: `hues` must be a non-empty array of finite degree offsets");
+  }
+  // Same reason: a non-finite jitter propagates NaN into cx/cy/rx/ry and lands
+  // malformed geometry in the SVG instead of raising.
+  if (!Number.isFinite(jitter)) {
+    throw new TypeError("variantSpec: `jitter` must be a finite number");
   }
   // ONE hue offset per seed, drawn from the fixed enum.
   const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -259,7 +259,11 @@ function fnv1a(str) {
 // Deterministic float in [0, 1) from a seed + key pair. Same inputs always
 // give the same output on any runtime.
 export function seededTrait(seed, key) {
-  return fnv1a(String(seed) + "|" + String(key)) / 0x100000000;
+  // JSON-encode the pair rather than joining on a separator. A plain "|" join
+  // is ambiguous: ("a|b", "c") and ("a", "b|c") both hash "a|b|c" and return the
+  // same trait, so a seed containing the separator could silently collide with
+  // another entity — the exact opposite of what a roster is for.
+  return fnv1a(JSON.stringify([String(seed), String(key)])) / 0x100000000;
 }
 
 // colour helpers for variantSpec — hex ↔ HSL ↔ rotate

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -319,8 +319,18 @@ function hslToRgbStr({ h, s, l }) {
   const b = Math.round(hue2rgb(p, q, h - 1 / 3) * 255);
   return "#" + [r, g, b].map(v => v.toString(16).padStart(2, "0")).join("");
 }
+// #rgb, #rgba, #rrggbb, #rrggbbaa — the forms hexToRgb can actually read.
+const HEX_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 function rotateHex(hex, degrees) {
+  // Non-hex palette values (`none`, a keyword, a url()) pass through untouched.
   if (!hex || hex === "none" || !hex.startsWith("#")) return hex;
+  // A malformed hex must NOT slip through. parseInt returns NaN, and
+  // (NaN >> 16) & 255 is 0, so `#ggg` would render solid black with no warning —
+  // the same silent-wrong-result assertRosterOpts exists to prevent.
+  if (!HEX_RE.test(hex)) {
+    throw new TypeError(`variantSpec: malformed hex colour in palette: ${hex}`);
+  }
   const { r, g, b } = hexToRgb(hex);
   const hsl = rgbToHsl(r, g, b);
   hsl.h = ((hsl.h + degrees) % 360 + 360) % 360;

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -270,7 +270,8 @@ function hexToRgb(hex) {
 function rgbToHsl(r, g, b) {
   r /= 255; g /= 255; b /= 255;
   const mx = Math.max(r, g, b), mn = Math.min(r, g, b);
-  let h = 0, s = 0, l = (mx + mn) / 2;
+  const l = (mx + mn) / 2;
+  let h = 0, s = 0;
   if (mx !== mn) {
     const d = mx - mn;
     s = l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
@@ -280,20 +281,23 @@ function rgbToHsl(r, g, b) {
   }
   return { h: h * 360, s: s * 100, l: l * 100 };
 }
+// Hoisted rather than nested: it captures nothing, so defining it inside
+// hslToRgbStr would rebuild the closure on every colour conversion.
+function hue2rgb(p, q, t) {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
 function hslToRgbStr({ h, s, l }) {
   h /= 360; s /= 100; l /= 100;
   if (s === 0) {
     const g = Math.round(l * 255);
     return "#" + [g, g, g].map(v => v.toString(16).padStart(2, "0")).join("");
   }
-  const hue2rgb = (p, q, t) => {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-    return p;
-  };
   const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
   const p = 2 * l - q;
   const r = Math.round(hue2rgb(p, q, h + 1 / 3) * 255);
@@ -313,30 +317,38 @@ function rotateHex(hex, degrees) {
 // keyed on `seed`. Colour hues rotate from a fixed, enumerable set. Silhouette
 // geometry jitters independently per part property. Face parts pass through
 // untouched — that keeps the roster one character.
-export function variantSpec(spec, seed, opts = {}) {
-  const { jitter = 0.06, hues = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324] } = opts;
-  // pick ONE hue offset from the enum for this seed
-  const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];
-
-  // deep-clone parts (face = without silhouette:true)
-  const parts = spec.parts.map(p => ({ ...p }));
-
-  // rotate palette — never touch ink
-  const palette = {};
-  for (const [k, v] of Object.entries(spec.palette)) {
-    palette[k] = k === "ink" ? v : rotateHex(v, hueOff);
+// Rotate every palette entry except ink, which keeps the linework constant.
+function rotatePalette(palette, hueOff) {
+  const out = {};
+  for (const [k, v] of Object.entries(palette)) {
+    out[k] = k === "ink" ? v : rotateHex(v, hueOff);
   }
+  return out;
+}
 
-  // jitter silhouette geometry independently per part per property
-  for (const p of parts) {
-    if (!p.silhouette) continue;
-    for (const prop of ["rx", "ry", "cx", "cy"]) {
+// Jitter silhouette geometry only, independently per part and per property.
+// Face parts (no silhouette flag) are returned untouched — that is what keeps
+// a roster one character rather than a set of unrelated creatures.
+const JITTERED = ["rx", "ry", "cx", "cy"];
+function jitterSilhouettes(parts, seed, jitter) {
+  return parts.map(part => {
+    const p = { ...part };
+    if (!p.silhouette) return p;
+    for (const prop of JITTERED) {
       if (p[prop] === undefined) continue;
-      const t = seededTrait(seed, p.id + "|" + prop);
-      const offset = (t * 2 - 1) * jitter;
+      const offset = (seededTrait(seed, p.id + "|" + prop) * 2 - 1) * jitter;
       p[prop] = p[prop] * (1 + offset);
     }
-  }
+    return p;
+  });
+}
+
+export function variantSpec(spec, seed, opts = {}) {
+  const { jitter = 0.06, hues = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324] } = opts;
+  // ONE hue offset per seed, drawn from the fixed enum.
+  const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];
+  const palette = rotatePalette(spec.palette, hueOff);
+  const parts = jitterSilhouettes(spec.parts, seed, jitter);
 
   // Spread rather than enumerate. Listing fields by hand means any spec key
   // added later — a new animation block, metadata, anything — is silently

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -264,7 +264,12 @@ export function seededTrait(seed, key) {
 
 // colour helpers for variantSpec — hex ↔ HSL ↔ rotate
 function hexToRgb(hex) {
-  const v = parseInt(hex.slice(1), 16);
+  // Expand #abc to #aabbcc first. Without this, parseInt("fff", 16) reads as
+  // 0x000fff, so #fff would rotate as rgb(0, 15, 255) instead of white — wrong
+  // colours from a perfectly valid palette, even at hue offset 0.
+  let h = hex.slice(1);
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const v = parseInt(h, 16);
   return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
 }
 function rgbToHsl(r, g, b) {
@@ -345,6 +350,12 @@ function jitterSilhouettes(parts, seed, jitter) {
 
 export function variantSpec(spec, seed, opts = {}) {
   const { jitter = 0.06, hues = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324] } = opts;
+  // Fail loudly on an empty set. Left alone, hueOff is undefined, rotateHex
+  // rotates by NaN, and every variant comes out greyscale — a silent, puzzling
+  // wrong result from what is plainly a config mistake.
+  if (!Array.isArray(hues) || hues.length === 0) {
+    throw new TypeError("variantSpec: `hues` must be a non-empty array of degree offsets");
+  }
   // ONE hue offset per seed, drawn from the fixed enum.
   const hueOff = hues[Math.floor(seededTrait(seed, "hue") * hues.length)];
   const palette = rotatePalette(spec.palette, hueOff);

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -240,3 +240,21 @@ describe("variantSpec – hex forms and numeric config", () => {
     assert.doesNotThrow(() => variantSpec(spec, "a", { jitter: 0.999 }));
   });
 });
+
+describe("variantSpec – malformed palette values", () => {
+  // parseInt("ggg", 16) is NaN and (NaN >> 16) & 255 is 0, so this would have
+  // rendered solid black with no warning.
+  it("throws on a malformed hex colour", () => {
+    for (const bad of ["#ggg", "#12345", "#xyzxyz"]) {
+      const broken = JSON.parse(JSON.stringify(spec));
+      broken.palette.body = bad;
+      assert.throws(() => variantSpec(broken, "a", { hues: [90] }), TypeError, bad);
+    }
+  });
+
+  it("passes non-hex palette values through untouched", () => {
+    const keyworded = JSON.parse(JSON.stringify(spec));
+    keyworded.palette.body = "none";
+    assert.equal(variantSpec(keyworded, "a", { hues: [90] }).palette.body, "none");
+  });
+});

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -229,7 +229,14 @@ describe("variantSpec – hex forms and numeric config", () => {
     assert.throws(() => variantSpec(spec, "a", { hues: [0, Infinity] }), TypeError);
   });
 
-  it("rejects a non-finite jitter", () => {
-    assert.throws(() => variantSpec(spec, "a", { jitter: NaN }), TypeError);
+  it("rejects a jitter outside [0, 1)", () => {
+    for (const bad of [NaN, Infinity, -0.1, 1, Number.MAX_VALUE]) {
+      assert.throws(() => variantSpec(spec, "a", { jitter: bad }), RangeError, String(bad));
+    }
+  });
+
+  it("accepts the bounds of the jitter range", () => {
+    assert.doesNotThrow(() => variantSpec(spec, "a", { jitter: 0 }));
+    assert.doesNotThrow(() => variantSpec(spec, "a", { jitter: 0.999 }));
   });
 });

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -1,0 +1,192 @@
+// vibebrand · mascot engine tests (node:test, zero dependencies)
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  seededTrait,
+  variantSpec,
+  renderRoster,
+  renderAvatar,
+} from "./engine.js";
+
+// Quiet helper: load the reference spec without import assertions
+import { readFileSync } from "node:fs";
+const spec = JSON.parse(readFileSync(new URL("rabbit.avatar.json", import.meta.url), "utf-8"));
+
+// Grab the default hue set so tests reference the same constant
+const DEFAULT_HUES = [0, 36, 72, 108, 144, 180, 216, 252, 288, 324];
+
+describe("seededTrait", () => {
+  it("returns a float in [0, 1)", () => {
+    for (const seed of ["alice", "bob", "", "\0", "你好"]) {
+      const t = seededTrait(seed, "hue");
+      assert(t >= 0, `${seed}: expected >= 0, got ${t}`);
+      assert(t < 1, `${seed}: expected < 1, got ${t}`);
+    }
+  });
+
+  it("is deterministic — same inputs always give the same output", () => {
+    const a = seededTrait("alice", "hue");
+    for (let i = 0; i < 20; i++) {
+      assert.strictEqual(seededTrait("alice", "hue"), a);
+    }
+  });
+
+  it("differs across seeds", () => {
+    const seen = new Set();
+    for (const seed of ["alice", "bob", "carol", "dave", "eve", "frank"]) {
+      seen.add(seededTrait(seed, "hue"));
+    }
+    assert(seen.size > 1, "expected at least two distinct values across seeds");
+  });
+
+  it("differs across keys for the same seed", () => {
+    assert.notStrictEqual(seededTrait("alice", "hue"), seededTrait("alice", "earL|rx"));
+  });
+});
+
+describe("variantSpec – immutability", () => {
+  it("does NOT mutate the input spec", () => {
+    const before = JSON.stringify(spec);
+    variantSpec(spec, "alice");
+    const after = JSON.stringify(spec);
+    assert.strictEqual(after, before, "input spec was mutated");
+  });
+});
+
+describe("variantSpec – determinism", () => {
+  it("same seed gives byte-identical output twice", () => {
+    const a = JSON.stringify(variantSpec(spec, "alice"));
+    const b = JSON.stringify(variantSpec(spec, "alice"));
+    assert.strictEqual(b, a);
+  });
+});
+
+describe("variantSpec – palette", () => {
+  it("two different seeds give different body palettes (at least one of 5 differs)", () => {
+    const colors = new Set();
+    for (const seed of ["alice", "bob", "carol", "dave", "eve"]) {
+      colors.add(variantSpec(spec, seed).palette.body);
+    }
+    // With 5 seeds and 10 hue slots, probability all 5 hit the same offset is
+    // 10 * (1/10)^5 = 0.001 — practically guaranteed to see at least 2 distinct.
+    assert(colors.size > 1, `expected at least 2 distinct body colors across 5 seeds, got ${colors.size}`);
+  });
+
+  it("ink is never hue-rotated", () => {
+    for (const seed of ["alice", "bob", "carol", "dave", "eve"]) {
+      assert.strictEqual(variantSpec(spec, seed).palette.ink, spec.palette.ink,
+        `ink changed for seed ${seed}`);
+    }
+  });
+
+  it("every generated palette colour comes from the fixed hue set — ≤10 distinct body colours over 200 seeds", () => {
+    const colors = new Set();
+    const seeds = Array.from({ length: 200 }, (_, i) => "s" + i);
+    for (const seed of seeds) {
+      colors.add(variantSpec(spec, seed).palette.body);
+    }
+    assert(colors.size <= DEFAULT_HUES.length,
+      `expected ≤${DEFAULT_HUES.length} distinct body colours, got ${colors.size}`);
+  });
+});
+
+describe("variantSpec – silhouette", () => {
+  it("face parts (no silhouette:true) are geometrically unchanged vs the source", () => {
+    const faceIds = new Set(["eyeL", "eyeR", "nose", "mouth"]);
+    const sourceParts = spec.parts.filter(p => faceIds.has(p.id));
+
+    for (const seed of ["alice", "bob", "carol"]) {
+      const variant = variantSpec(spec, seed);
+      for (const sp of sourceParts) {
+        const vp = variant.parts.find(p => p.id === sp.id);
+        for (const k of Object.keys(sp)) {
+          if (k === "id") continue;
+          assert.strictEqual(vp[k], sp[k],
+            `face part "${sp.id}" property "${k}" changed for seed "${seed}": ${vp[k]} !== ${sp[k]}`);
+        }
+      }
+    }
+  });
+
+  it("silhouette parts have geometry jittered", () => {
+    const silIds = new Set(["earL", "earR", "head", "body"]);
+    // Use a seed likely to jitter perceptibly — but any seed works if we compare
+    // at least one property. We accept that a 0-jitter effect of the random
+    // offset on a large value could round to the same; we just check at least
+    // one property changed.
+    let changed = false;
+    for (const seed of ["jittertest1", "jittertest2", "jittertest3"]) {
+      const variant = variantSpec(spec, seed);
+      for (const id of silIds) {
+        const orig = spec.parts.find(p => p.id === id);
+        const vp = variant.parts.find(p => p.id === id);
+        for (const prop of ["rx", "ry", "cx", "cy"]) {
+          if (orig[prop] === undefined) continue;
+          // Jittered values should differ — because the offset is non-zero and
+          // the value is multiplied by (1 + offset), the only way it can round
+          // to the same is if offset = 0 exactly (which has probability ~0).
+          if (Math.abs(vp[prop] - orig[prop]) > 1e-10) changed = true;
+        }
+      }
+    }
+    assert(changed, "expected at least one silhouette property to jitter across 3 seeds");
+  });
+});
+
+describe("renderRoster", () => {
+  it("returns one entry per seed", () => {
+    const roster = renderRoster(spec, ["alice", "bob", "carol"]);
+    assert.strictEqual(roster.length, 3);
+    assert.strictEqual(roster[0].seed, "alice");
+    assert.strictEqual(roster[2].seed, "carol");
+  });
+
+  it("every entry is an SVG string", () => {
+    const roster = renderRoster(spec, ["alice", "bob"]);
+    for (const entry of roster) {
+      assert(typeof entry.svg === "string");
+      assert(entry.svg.startsWith("<svg"));
+      assert(entry.svg.endsWith("</svg>"));
+    }
+  });
+
+  it("two different seeds produce different SVG output", () => {
+    const [a, b] = renderRoster(spec, ["alice", "bob"]).map(e => e.svg);
+    // Palette differs so SVGs must differ
+    assert.notStrictEqual(a, b);
+  });
+});
+
+describe("variantSpec – opts passthrough", () => {
+  it("accepts custom hues", () => {
+    const hues = [0, 90, 180, 270];
+    for (const seed of ["a", "b", "c", "d", "e"]) {
+      const v = variantSpec(spec, seed, { hues });
+      assert.notStrictEqual(v.palette.body, spec.palette.body);
+    }
+  });
+
+  it("accepts custom jitter", () => {
+    const v1 = variantSpec(spec, "alice", { jitter: 0 });
+    const v2 = variantSpec(spec, "alice", { jitter: 0.2 });
+    // With jitter=0, geometry should match source exactly
+    const origBody = spec.parts.find(p => p.id === "body");
+    const v1Body = v1.parts.find(p => p.id === "body");
+    assert.strictEqual(v1Body.cx, origBody.cx, "jitter=0 should leave cx unchanged");
+    // With jitter=0.2 they should differ
+    const v2Body = v2.parts.find(p => p.id === "body");
+    assert.notStrictEqual(v2Body.cx, origBody.cx);
+  });
+});
+
+describe("variantSpec – forward compatibility", () => {
+  // A spec field the engine does not know about must survive into every variant.
+  // Enumerating fields by hand drops it silently, and only on rosters, so the
+  // regression would surface long after the field was added.
+  it("preserves unknown spec fields", () => {
+    const extended = JSON.parse(JSON.stringify(spec));
+    extended.futureField = { anything: 1 };
+    const out = variantSpec(extended, "seed-a");
+    assert.deepStrictEqual(out.futureField, { anything: 1 });
+  });
+});

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -5,7 +5,6 @@ import {
   seededTrait,
   variantSpec,
   renderRoster,
-  renderAvatar,
 } from "./engine.js";
 
 // Quiet helper: load the reference spec without import assertions

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -189,3 +189,27 @@ describe("variantSpec – forward compatibility", () => {
     assert.deepStrictEqual(out.futureField, { anything: 1 });
   });
 });
+
+describe("variantSpec – colour parsing", () => {
+  // #fff must not be read as 0x000fff. A 3-digit palette entry would otherwise
+  // come out a wrong colour even at hue offset 0, from a valid spec.
+  it("expands 3-digit hex before rotating", () => {
+    const white = JSON.parse(JSON.stringify(spec));
+    white.palette.body = "#fff";
+    // Hue rotation of a zero-saturation colour must leave it white.
+    const out = variantSpec(white, "any-seed", { hues: [180] });
+    assert.equal(out.palette.body.toLowerCase(), "#ffffff");
+  });
+});
+
+describe("variantSpec – config validation", () => {
+  // An empty set left hueOff undefined, rotateHex rotated by NaN, and every
+  // variant silently came out greyscale. A throw names the mistake instead.
+  it("rejects an empty hue set", () => {
+    assert.throws(() => variantSpec(spec, "a", { hues: [] }), TypeError);
+  });
+
+  it("rejects a non-array hue set", () => {
+    assert.throws(() => variantSpec(spec, "a", { hues: 180 }), TypeError);
+  });
+});

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -213,3 +213,23 @@ describe("variantSpec – config validation", () => {
     assert.throws(() => variantSpec(spec, "a", { hues: 180 }), TypeError);
   });
 });
+
+describe("variantSpec – hex forms and numeric config", () => {
+  it("handles 4- and 8-digit alpha hex without folding alpha into RGB", () => {
+    for (const value of ["#ffff", "#ffffffff"]) {
+      const withAlpha = JSON.parse(JSON.stringify(spec));
+      withAlpha.palette.body = value;
+      const out = variantSpec(withAlpha, "a", { hues: [180] });
+      assert.equal(out.palette.body.toLowerCase(), "#ffffff", value);
+    }
+  });
+
+  it("rejects non-finite hue offsets", () => {
+    assert.throws(() => variantSpec(spec, "a", { hues: [NaN] }), TypeError);
+    assert.throws(() => variantSpec(spec, "a", { hues: [0, Infinity] }), TypeError);
+  });
+
+  it("rejects a non-finite jitter", () => {
+    assert.throws(() => variantSpec(spec, "a", { jitter: NaN }), TypeError);
+  });
+});

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -158,11 +158,20 @@ describe("renderRoster", () => {
 
 describe("variantSpec – opts passthrough", () => {
   it("accepts custom hues", () => {
-    const hues = [0, 90, 180, 270];
+    // Deliberately excludes 0. With 0 in the set some seed will legitimately
+    // pick "no rotation" and keep the source colour, so asserting that every
+    // seed differs would be asserting something untrue — it only held before
+    // by luck of which offsets the hash happened to select.
+    const hues = [90, 180, 270];
     for (const seed of ["a", "b", "c", "d", "e"]) {
       const v = variantSpec(spec, seed, { hues });
-      assert.notStrictEqual(v.palette.body, spec.palette.body);
+      assert.notStrictEqual(v.palette.body, spec.palette.body, seed);
     }
+  });
+
+  it("treats a 0 offset as no rotation", () => {
+    const v = variantSpec(spec, "any", { hues: [0] });
+    assert.strictEqual(v.palette.body, spec.palette.body);
   });
 
   it("accepts custom jitter", () => {
@@ -256,5 +265,17 @@ describe("variantSpec – malformed palette values", () => {
     const keyworded = JSON.parse(JSON.stringify(spec));
     keyworded.palette.body = "none";
     assert.equal(variantSpec(keyworded, "a", { hues: [90] }).palette.body, "none");
+  });
+});
+
+describe("seededTrait – unambiguous encoding", () => {
+  // A plain "|" join made these two hash the same string, so a seed containing
+  // the separator could collide with an unrelated entity.
+  it("does not collide when the separator appears in the seed", () => {
+    assert.notEqual(seededTrait("a|b", "c"), seededTrait("a", "b|c"));
+  });
+
+  it("still collides for genuinely identical inputs", () => {
+    assert.equal(seededTrait("team|lead", "hue"), seededTrait("team|lead", "hue"));
   });
 });

--- a/package.json
+++ b/package.json
@@ -29,13 +29,18 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./mascot/engine.js": "./mascot/engine.js",
+    "./mascot/*.avatar.json": "./mascot/*.avatar.json",
+    "./package.json": "./package.json"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist",
+    "mascot/engine.js",
+    "mascot/*.avatar.json",
     "README.md"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibebrand",
   "version": "0.1.0",
-  "description": "Generate a complete, tokenized brand/design system — pick a direction, get CSS design tokens (light + dark), fonts, and a starting point for logo/favicon/OG. SDK + CLI (MCP coming). Productizes the saas-brand-system workflow.",
+  "description": "Generate a complete, tokenized brand/design system \u2014 pick a direction, get CSS design tokens (light + dark), fonts, and a starting point for logo/favicon/OG. SDK + CLI (MCP coming). Productizes the saas-brand-system workflow.",
   "keywords": [
     "branding",
     "design-system",
@@ -34,11 +34,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "test": "tsup && node dist/cli.js check --all",
+    "test": "node --test mascot/engine.test.mjs && tsup && node dist/cli.js check --all",
     "test:unit": "node --test mascot/engine.test.mjs",
     "prepublishOnly": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vibebrand",
   "version": "0.1.0",
-  "description": "Generate a complete, tokenized brand/design system \u2014 pick a direction, get CSS design tokens (light + dark), fonts, and a starting point for logo/favicon/OG. SDK + CLI (MCP coming). Productizes the saas-brand-system workflow.",
+  "description": "Generate a complete, tokenized brand/design system — pick a direction, get CSS design tokens (light + dark), fonts, and a starting point for logo/favicon/OG. SDK + CLI (MCP coming). Productizes the saas-brand-system workflow.",
   "keywords": [
     "branding",
     "design-system",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "test": "tsup && node dist/cli.js check --all",
+    "test:unit": "node --test mascot/engine.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {


### PR DESCRIPTION
## The gap

The engine renders **one character per `.avatar.json`**. Any product with many named
entities — agents, teammates, workspaces, tenants — needs a **roster**: N variants that
are visibly distinct but obviously the same character. Today you would hand-author N
spec files, which then drift apart.

```js
import { renderRoster } from "vibebrand/mascot/engine.js";
renderRoster(spec, ["alice", "bob", "carol"]);  // [{ seed, svg }, ...]
```

`variantSpec(spec, seed)` derives a variant deterministically — the same name always
yields the same character, so nothing has to be stored or chosen.

## The two rules that make it read as a brand

**Colour rotates by one offset from a fixed, enumerable hue set** (ten by default).
This is easy to get wrong in *both* directions:

| Approach | Result across a large roster |
|---|---|
| Free 0–360 rotation | A new colour per entity; stops looking like one palette |
| One locked hue | Entities become indistinguishable at avatar size |
| **Fixed set of N** | Distinct *and* bounded — the same N colours forever |

`ink` never rotates, so linework stays constant across the whole roster.

**Only `silhouette: true` parts are jittered** — independently per part and per property,
keyed on the part `id` so they are stable. Eyes, nose and mouth pass through untouched.
Holding the face constant is precisely what makes a roster one character in different
bodies rather than a set of unrelated creatures.

## One thing worth reviewing

`variantSpec` clones by **spreading**, not by listing fields. An earlier draft enumerated
the nine keys the current specs happen to have — which works today and would silently
drop any spec key added later, surfacing only on rosters and only long after the field
was added. There is a test for it.

## Tests

Adds `mascot/engine.test.mjs` — **the first tests in this repo** — runnable with
`node --test` via a new `test:unit` script. 17 tests: determinism, non-mutation, the face
staying geometrically unchanged, `ink` never rotating, the palette staying bounded across
200 seeds, and forward compatibility.

`bun run typecheck` and `bun run build` both pass. Zero new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic mascot roster generation from a shared avatar specification.
  - Supports stable palette variations, silhouette adjustments, and consistent facial features across variants.
  - Added options for custom hue rotation and silhouette variation.

- **Documentation**
  - Expanded mascot-system documentation with roster examples and usage guidance.

- **Tests**
  - Added comprehensive automated coverage for deterministic variants, rendering, customization, and data preservation.
  - Added an npm command for running unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->