### PR TITLE
[VB-16] Adopt the fleet PR standard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,5 @@ Assisted-by: <agent>:<model>
 <!--
   One issue. One PR. One concern. Under 500 counted lines.
   Lockfiles, build output, snapshots, and migrations do not count against the cap.
-  If the change genuinely cannot be split, say why here and ask for the
-  `oversized-approved` label. Do not add the label yourself.
+  There is no label that clears the cap. Split the change.
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
 <!-- pr-standards:start -->
+
 ## Pull requests
 
 One issue. One PR. One concern. Under 500 counted lines.
@@ -21,10 +22,10 @@ Write "Fix the drop-off", not "Fixed the drop-off".
 
 Hard caps, failed by the `pr-standards` CI check: 500 counted lines, 40 counted
 files, exactly one `Closes #`. Lockfiles, build output, snapshots, generated
-code and migrations are not counted. If a change genuinely cannot be split, say
-why in the body and ask for the `oversized-approved` label. Do not apply that
-label yourself.
+code and migrations are not counted. There is no label that clears the cap and
+no one to ask for one. Split the change.
 
 Settings for this repo are in `.github/pr-standards.json`. The standard is at
 https://github.com/pooriaarab/scripts/blob/main/pr-standards.md
+
 <!-- pr-standards:end -->


### PR DESCRIPTION
Closes #16

## What

Adopts the fleet PR standard in this repo. Adds `.github/pr-standards.json`
(prefix `vb`), a pull request template, the `pr-standards` CI check, and
the standard block in `AGENTS.md`.

## Why

Agents open pull requests faster than anyone reviews them. This repo gets the
same rule as the rest of the fleet: one issue, one PR, one concern, under 500
counted lines. From here on, branches are `vb-<issue>-<slug>` and titles
are `[VB-<issue>] Subject`.

The standard: https://github.com/pooriaarab/scripts/blob/main/pr-standards.md

## How I verified

The check this PR installs, run against the branch and title this PR opens:

```text
$ export GITHUB_REPOSITORY=pooriaarab/vibebrand
$ ./pr-standards precheck --branch vb-16-adopt-pr-standard --title '[VB-16] Adopt the fleet PR standard'
fatal: not a git repository (or any of the parent directories): .git
Using prefix: vb (from .github/pr-standards.json)
PASS  branch name: vb-16-adopt-pr-standard
PASS  PR title
```

The remaining rules -- the body's shape, the size caps, the commit trailers --
are judged by the same checker when it runs on this PR.

Assisted-by: pooriaarab/scripts:pr-standards-rollout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated pull request guidance to require splitting changes that exceed line-count limits.
  - Removed the previous exception process involving justification and special approval labels.
  - Clarified contribution standards for oversized changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->