### PR TITLE
[VB-20] Adopt oxfmt as the formatter (part 2 of 8)

### DIFF
--- a/mascot/bat.avatar.json
+++ b/mascot/bat.avatar.json
@@ -16,68 +16,247 @@
   "parts": [
     { "id": "field", "type": "rect", "x": 0, "y": 0, "w": 400, "h": 400, "fill": "field" },
 
-    { "id": "wingL", "type": "path", "silhouette": true, "fill": "body",
-      "d": "M188 340 C96 306 24 234 18 84 C40 146 78 186 116 196 C88 224 116 264 152 274 C120 300 156 342 190 350 C190 346 188 342 188 340 Z" },
-    { "id": "wingLm", "type": "path", "fill": "membrane",
-      "d": "M188 332 C110 302 46 240 40 102 C60 156 92 190 128 200 C104 224 128 260 162 270 C134 292 164 328 188 336 C188 334 188 333 188 332 Z" },
-    { "id": "wingR", "type": "path", "silhouette": true, "fill": "body",
-      "d": "M316 340 C408 306 480 234 486 84 C464 146 426 186 388 196 C416 224 388 264 352 274 C384 300 348 342 314 350 C314 346 316 342 316 340 Z" },
-    { "id": "wingRm", "type": "path", "fill": "membrane",
-      "d": "M316 332 C394 302 458 240 464 102 C444 156 412 190 376 200 C400 224 376 260 342 270 C370 292 340 328 316 336 C316 334 316 333 316 332 Z" },
+    {
+      "id": "wingL",
+      "type": "path",
+      "silhouette": true,
+      "fill": "body",
+      "d": "M188 340 C96 306 24 234 18 84 C40 146 78 186 116 196 C88 224 116 264 152 274 C120 300 156 342 190 350 C190 346 188 342 188 340 Z"
+    },
+    {
+      "id": "wingLm",
+      "type": "path",
+      "fill": "membrane",
+      "d": "M188 332 C110 302 46 240 40 102 C60 156 92 190 128 200 C104 224 128 260 162 270 C134 292 164 328 188 336 C188 334 188 333 188 332 Z"
+    },
+    {
+      "id": "wingR",
+      "type": "path",
+      "silhouette": true,
+      "fill": "body",
+      "d": "M316 340 C408 306 480 234 486 84 C464 146 426 186 388 196 C416 224 388 264 352 274 C384 300 348 342 314 350 C314 346 316 342 316 340 Z"
+    },
+    {
+      "id": "wingRm",
+      "type": "path",
+      "fill": "membrane",
+      "d": "M316 332 C394 302 458 240 464 102 C444 156 412 190 376 200 C400 224 376 260 342 270 C370 292 340 328 316 336 C316 334 316 333 316 332 Z"
+    },
 
-    { "id": "earL", "type": "path", "silhouette": true, "fill": "body",
-      "d": "M196 180 L206 74 Q214 62 224 76 L268 176 Q232 190 196 180 Z" },
-    { "id": "earR", "type": "path", "silhouette": true, "fill": "body",
-      "d": "M316 180 L306 74 Q298 62 288 76 L244 176 Q280 190 316 180 Z" },
-    { "id": "innerL", "type": "path", "fill": "membrane",
-      "d": "M206 172 L214 98 Q219 90 224 100 L252 168 Q228 178 206 172 Z" },
-    { "id": "innerR", "type": "path", "fill": "membrane",
-      "d": "M306 172 L298 98 Q293 90 288 100 L260 168 Q284 178 306 172 Z" },
+    {
+      "id": "earL",
+      "type": "path",
+      "silhouette": true,
+      "fill": "body",
+      "d": "M196 180 L206 74 Q214 62 224 76 L268 176 Q232 190 196 180 Z"
+    },
+    {
+      "id": "earR",
+      "type": "path",
+      "silhouette": true,
+      "fill": "body",
+      "d": "M316 180 L306 74 Q298 62 288 76 L244 176 Q280 190 316 180 Z"
+    },
+    {
+      "id": "innerL",
+      "type": "path",
+      "fill": "membrane",
+      "d": "M206 172 L214 98 Q219 90 224 100 L252 168 Q228 178 206 172 Z"
+    },
+    {
+      "id": "innerR",
+      "type": "path",
+      "fill": "membrane",
+      "d": "M306 172 L298 98 Q293 90 288 100 L260 168 Q284 178 306 172 Z"
+    },
 
-    { "id": "head", "type": "ellipse", "silhouette": true, "cx": 256, "cy": 250, "rx": 116, "ry": 104, "fill": "body" },
-    { "id": "body", "type": "ellipse", "silhouette": true, "cx": 252, "cy": 430, "rx": 138, "ry": 128, "fill": "body" },
+    {
+      "id": "head",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 256,
+      "cy": 250,
+      "rx": 116,
+      "ry": 104,
+      "fill": "body"
+    },
+    {
+      "id": "body",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 252,
+      "cy": 430,
+      "rx": 138,
+      "ry": 128,
+      "fill": "body"
+    },
 
-    { "id": "eyeWL", "type": "ellipse", "cx": 218, "cy": 244, "rx": 24, "ry": 27, "fill": "membrane" },
-    { "id": "eyeWR", "type": "ellipse", "cx": 300, "cy": 240, "rx": 24, "ry": 27, "fill": "membrane" },
+    {
+      "id": "eyeWL",
+      "type": "ellipse",
+      "cx": 218,
+      "cy": 244,
+      "rx": 24,
+      "ry": 27,
+      "fill": "membrane"
+    },
+    {
+      "id": "eyeWR",
+      "type": "ellipse",
+      "cx": 300,
+      "cy": 240,
+      "rx": 24,
+      "ry": 27,
+      "fill": "membrane"
+    },
     { "id": "eyeL", "type": "ellipse", "cx": 224, "cy": 248, "rx": 11, "ry": 13, "fill": "ink" },
     { "id": "eyeR", "type": "ellipse", "cx": 294, "cy": 244, "rx": 11, "ry": 13, "fill": "ink" },
     { "id": "hiL", "type": "circle", "cx": 228, "cy": 243, "r": 4, "fill": "hi" },
     { "id": "hiR", "type": "circle", "cx": 298, "cy": 239, "r": 4, "fill": "hi" },
-    { "id": "snout", "type": "ellipse", "cx": 259, "cy": 276, "rx": 22, "ry": 16, "fill": "membrane" },
+    {
+      "id": "snout",
+      "type": "ellipse",
+      "cx": 259,
+      "cy": 276,
+      "rx": 22,
+      "ry": 16,
+      "fill": "membrane"
+    },
     { "id": "nostrilL", "type": "ellipse", "cx": 252, "cy": 276, "rx": 3, "ry": 4, "fill": "ink" },
     { "id": "nostrilR", "type": "ellipse", "cx": 266, "cy": 276, "rx": 3, "ry": 4, "fill": "ink" },
-    { "id": "mouth", "type": "path", "d": "M244 292 Q259 304 274 292", "fill": "none", "stroke": "membrane", "strokeWidth": 6 },
+    {
+      "id": "mouth",
+      "type": "path",
+      "d": "M244 292 Q259 304 274 292",
+      "fill": "none",
+      "stroke": "membrane",
+      "strokeWidth": 6
+    },
     { "id": "fang", "type": "path", "d": "M264 300 L272 300 L268 312 Z", "fill": "hi" }
   ],
   "expressions": {
     "happy": {},
     "content": {
-      "eyeL": { "type": "path", "d": "M211 248 q13 -14 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M281 244 q13 -14 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M211 248 q13 -14 26 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M281 244 q13 -14 26 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "surprised": {
-      "eyeL": { "ry": 16 }, "eyeR": { "ry": 16 },
-      "mouth": { "type": "ellipse", "cx": 259, "cy": 298, "rx": 8, "ry": 10, "fill": "membrane", "stroke": null, "strokeWidth": null, "d": null }
+      "eyeL": { "ry": 16 },
+      "eyeR": { "ry": 16 },
+      "mouth": {
+        "type": "ellipse",
+        "cx": 259,
+        "cy": 298,
+        "rx": 8,
+        "ry": 10,
+        "fill": "membrane",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sleepy": {
-      "eyeL": { "type": "path", "d": "M211 246 q13 11 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M281 242 q13 11 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M211 246 q13 11 26 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M281 242 q13 11 26 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "wink": {
-      "eyeL": { "type": "path", "d": "M211 246 q13 11 26 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M211 246 q13 11 26 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
       "hiL": { "fill": null }
     },
     "excited": {
       "eyeL": { "rx": 13.5, "ry": 16 },
       "eyeR": { "rx": 13.5, "ry": 16 },
-      "mouth": { "type": "ellipse", "cx": 259, "cy": 298, "rx": 13, "ry": 11, "fill": "membrane", "stroke": null, "strokeWidth": null, "d": null }
+      "mouth": {
+        "type": "ellipse",
+        "cx": 259,
+        "cy": 298,
+        "rx": 13,
+        "ry": 11,
+        "fill": "membrane",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sad": {
-      "eyeL": { "type": "path", "d": "M211 252 q13 -11 26 -6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M281 240 q13 -7 26 6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M211 252 q13 -11 26 -6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M281 240 q13 -7 26 6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null },
       "mouth": { "d": "M244 302 Q259 288 274 302" }
     },
     "skeptical": {
@@ -95,9 +274,34 @@
     "idle": {
       "loop": true,
       "tracks": [
-        { "target": ["head", "body"], "property": "translateY", "keys": [[0, 0], [1.3, -2.5], [2.6, 0]] },
-        { "target": ["wingL", "wingLm", "wingR", "wingRm"], "property": "rotate", "keys": [[0, -4], [1.0, 4], [2.0, -4]] },
-        { "target": ["eyeL", "eyeR"], "property": "scaleY", "keys": [[0, 1], [3.9, 1], [4.05, 0.1], [4.2, 1]] }
+        {
+          "target": ["head", "body"],
+          "property": "translateY",
+          "keys": [
+            [0, 0],
+            [1.3, -2.5],
+            [2.6, 0]
+          ]
+        },
+        {
+          "target": ["wingL", "wingLm", "wingR", "wingRm"],
+          "property": "rotate",
+          "keys": [
+            [0, -4],
+            [1.0, 4],
+            [2.0, -4]
+          ]
+        },
+        {
+          "target": ["eyeL", "eyeR"],
+          "property": "scaleY",
+          "keys": [
+            [0, 1],
+            [3.9, 1],
+            [4.05, 0.1],
+            [4.2, 1]
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
Closes #20

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the 1 files it covers.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 2 of 8, stacked on `vb-18-adopt-oxfmt-part1`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vb-18-adopt-oxfmt-part1                 -> 1 files, 280 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
