### PR TITLE
[VB-22] Adopt oxfmt as the formatter (part 3 of 8)

### DIFF
--- a/mascot/sheep.avatar.json
+++ b/mascot/sheep.avatar.json
@@ -16,51 +16,238 @@
   },
   "parts": [
     { "id": "field", "type": "rect", "x": 0, "y": 0, "w": 400, "h": 400, "fill": "field" },
-    { "id": "woolBody", "type": "ellipse", "silhouette": true, "cx": 250, "cy": 488, "rx": 170, "ry": 150, "fill": "wool" },
-    { "id": "earL", "type": "ellipse", "silhouette": true, "cx": 150, "cy": 316, "rx": 32, "ry": 22, "rotate": 22, "fill": "ear" },
-    { "id": "earR", "type": "ellipse", "silhouette": true, "cx": 372, "cy": 300, "rx": 32, "ry": 22, "rotate": -22, "fill": "ear" },
-    { "id": "wool0", "type": "ellipse", "silhouette": true, "cx": 256, "cy": 284, "rx": 138, "ry": 126, "fill": "wool" },
-    { "id": "wool1", "type": "circle", "silhouette": true, "cx": 178, "cy": 196, "r": 60, "fill": "wool" },
-    { "id": "wool2", "type": "circle", "silhouette": true, "cx": 264, "cy": 158, "r": 66, "fill": "wool" },
-    { "id": "wool3", "type": "circle", "silhouette": true, "cx": 350, "cy": 200, "r": 58, "fill": "wool" },
-    { "id": "wool4", "type": "circle", "silhouette": true, "cx": 144, "cy": 280, "r": 52, "fill": "wool" },
-    { "id": "wool5", "type": "circle", "silhouette": true, "cx": 372, "cy": 286, "r": 52, "fill": "wool" },
-    { "id": "faceO", "type": "ellipse", "cx": 268, "cy": 306, "rx": 112, "ry": 102, "fill": "face" },
+    {
+      "id": "woolBody",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 250,
+      "cy": 488,
+      "rx": 170,
+      "ry": 150,
+      "fill": "wool"
+    },
+    {
+      "id": "earL",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 150,
+      "cy": 316,
+      "rx": 32,
+      "ry": 22,
+      "rotate": 22,
+      "fill": "ear"
+    },
+    {
+      "id": "earR",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 372,
+      "cy": 300,
+      "rx": 32,
+      "ry": 22,
+      "rotate": -22,
+      "fill": "ear"
+    },
+    {
+      "id": "wool0",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 256,
+      "cy": 284,
+      "rx": 138,
+      "ry": 126,
+      "fill": "wool"
+    },
+    {
+      "id": "wool1",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 178,
+      "cy": 196,
+      "r": 60,
+      "fill": "wool"
+    },
+    {
+      "id": "wool2",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 264,
+      "cy": 158,
+      "r": 66,
+      "fill": "wool"
+    },
+    {
+      "id": "wool3",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 350,
+      "cy": 200,
+      "r": 58,
+      "fill": "wool"
+    },
+    {
+      "id": "wool4",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 144,
+      "cy": 280,
+      "r": 52,
+      "fill": "wool"
+    },
+    {
+      "id": "wool5",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 372,
+      "cy": 286,
+      "r": 52,
+      "fill": "wool"
+    },
+    {
+      "id": "faceO",
+      "type": "ellipse",
+      "cx": 268,
+      "cy": 306,
+      "rx": 112,
+      "ry": 102,
+      "fill": "face"
+    },
     { "id": "eyeL", "type": "ellipse", "cx": 240, "cy": 302, "rx": 16, "ry": 21, "fill": "ink" },
     { "id": "eyeR", "type": "ellipse", "cx": 326, "cy": 292, "rx": 16, "ry": 21, "fill": "ink" },
     { "id": "hiL", "type": "circle", "cx": 246, "cy": 294, "r": 5, "fill": "hi" },
     { "id": "hiR", "type": "circle", "cx": 332, "cy": 284, "r": 5, "fill": "hi" },
-    { "id": "mouth", "type": "path", "d": "M262 330 Q278 346 294 330", "fill": "none", "stroke": "ink", "strokeWidth": 7 }
+    {
+      "id": "mouth",
+      "type": "path",
+      "d": "M262 330 Q278 346 294 330",
+      "fill": "none",
+      "stroke": "ink",
+      "strokeWidth": 7
+    }
   ],
   "expressions": {
     "happy": {},
     "content": {
-      "eyeL": { "type": "path", "d": "M226 306 q14 -15 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M312 296 q14 -15 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M226 306 q14 -15 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M312 296 q14 -15 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "surprised": {
-      "eyeL": { "ry": 24 }, "eyeR": { "ry": 24 },
-      "mouth": { "type": "ellipse", "cx": 278, "cy": 334, "rx": 9, "ry": 11, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+      "eyeL": { "ry": 24 },
+      "eyeR": { "ry": 24 },
+      "mouth": {
+        "type": "ellipse",
+        "cx": 278,
+        "cy": 334,
+        "rx": 9,
+        "ry": 11,
+        "fill": "ink",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sleepy": {
-      "eyeL": { "type": "path", "d": "M226 302 q14 13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M312 292 q14 13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M226 302 q14 13 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M312 292 q14 13 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "wink": {
-      "eyeL": { "type": "path", "d": "M226 302 q14 13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M226 302 q14 13 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
       "hiL": { "fill": null }
     },
     "excited": {
       "eyeL": { "rx": 19, "ry": 24 },
       "eyeR": { "rx": 19, "ry": 24 },
-      "mouth": { "type": "ellipse", "cx": 278, "cy": 334, "rx": 14, "ry": 12, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+      "mouth": {
+        "type": "ellipse",
+        "cx": 278,
+        "cy": 334,
+        "rx": 14,
+        "ry": 12,
+        "fill": "ink",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sad": {
-      "eyeL": { "type": "path", "d": "M226 306 q14 -13 28 -6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "eyeR": { "type": "path", "d": "M312 294 q14 -7 28 6", "fill": "none", "stroke": "ink", "strokeWidth": 7, "cx": null, "cy": null, "rx": null, "ry": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M226 306 q14 -13 28 -6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M312 294 q14 -7 28 6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 7,
+        "cx": null,
+        "cy": null,
+        "rx": null,
+        "ry": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null },
       "mouth": { "d": "M264 342 Q278 326 292 342" }
     },
     "skeptical": {
@@ -70,7 +257,13 @@
   },
   "accessories": {
     "headset": [
-      { "type": "path", "d": "M150 300 Q268 150 386 300", "fill": "none", "stroke": "ink", "strokeWidth": 9 },
+      {
+        "type": "path",
+        "d": "M150 300 Q268 150 386 300",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 9
+      },
       { "type": "rect", "x": 134, "y": 292, "w": 28, "h": 42, "rx": 12, "fill": "accent" },
       { "type": "rect", "x": 372, "y": 292, "w": 28, "h": 42, "rx": 12, "fill": "accent" }
     ]
@@ -79,9 +272,34 @@
     "idle": {
       "loop": true,
       "tracks": [
-        { "target": "woolBody", "property": "translateY", "keys": [[0, 0], [1.3, -3], [2.6, 0]] },
-        { "target": ["earL", "earR"], "property": "rotate", "keys": [[0, -3], [1.7, 3], [3.4, -3]] },
-        { "target": ["eyeL", "eyeR"], "property": "scaleY", "keys": [[0, 1], [3.9, 1], [4.05, 0.1], [4.2, 1]] }
+        {
+          "target": "woolBody",
+          "property": "translateY",
+          "keys": [
+            [0, 0],
+            [1.3, -3],
+            [2.6, 0]
+          ]
+        },
+        {
+          "target": ["earL", "earR"],
+          "property": "rotate",
+          "keys": [
+            [0, -3],
+            [1.7, 3],
+            [3.4, -3]
+          ]
+        },
+        {
+          "target": ["eyeL", "eyeR"],
+          "property": "scaleY",
+          "keys": [
+            [0, 1],
+            [3.9, 1],
+            [4.05, 0.1],
+            [4.2, 1]
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
Closes #22

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the 1 files it covers.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 3 of 8, stacked on `vb-20-adopt-oxfmt-part2`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vb-20-adopt-oxfmt-part2                 -> 1 files, 274 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
