### PR TITLE
[VB-26] Adopt oxfmt as the formatter (part 5 of 8)

### DIFF
--- a/mascot/chameleon.avatar.json
+++ b/mascot/chameleon.avatar.json
@@ -15,53 +15,206 @@
   },
   "parts": [
     { "id": "field", "type": "rect", "x": 0, "y": 0, "w": 400, "h": 400, "fill": "field" },
-    { "id": "tail", "type": "path", "silhouette": true, "fill": "none", "stroke": "body", "strokeWidth": 26,
-      "d": "M150 372 C84 372 78 296 142 296 C192 296 196 352 150 352 C122 352 120 322 146 320" },
-    { "id": "crestL", "type": "path", "silhouette": true, "fill": "deep", "d": "M196 186 L210 158 L226 186 Z" },
-    { "id": "crest0", "type": "path", "silhouette": true, "fill": "deep", "d": "M228 180 L246 150 L264 180 Z" },
-    { "id": "crestR", "type": "path", "silhouette": true, "fill": "deep", "d": "M266 180 L286 152 L304 182 Z" },
-    { "id": "head", "type": "ellipse", "silhouette": true, "cx": 256, "cy": 290, "rx": 132, "ry": 118, "fill": "body" },
-    { "id": "body", "type": "ellipse", "silhouette": true, "cx": 252, "cy": 486, "rx": 156, "ry": 144, "fill": "body" },
+    {
+      "id": "tail",
+      "type": "path",
+      "silhouette": true,
+      "fill": "none",
+      "stroke": "body",
+      "strokeWidth": 26,
+      "d": "M150 372 C84 372 78 296 142 296 C192 296 196 352 150 352 C122 352 120 322 146 320"
+    },
+    {
+      "id": "crestL",
+      "type": "path",
+      "silhouette": true,
+      "fill": "deep",
+      "d": "M196 186 L210 158 L226 186 Z"
+    },
+    {
+      "id": "crest0",
+      "type": "path",
+      "silhouette": true,
+      "fill": "deep",
+      "d": "M228 180 L246 150 L264 180 Z"
+    },
+    {
+      "id": "crestR",
+      "type": "path",
+      "silhouette": true,
+      "fill": "deep",
+      "d": "M266 180 L286 152 L304 182 Z"
+    },
+    {
+      "id": "head",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 256,
+      "cy": 290,
+      "rx": 132,
+      "ry": 118,
+      "fill": "body"
+    },
+    {
+      "id": "body",
+      "type": "ellipse",
+      "silhouette": true,
+      "cx": 252,
+      "cy": 486,
+      "rx": 156,
+      "ry": 144,
+      "fill": "body"
+    },
     { "id": "belly", "type": "ellipse", "cx": 262, "cy": 344, "rx": 78, "ry": 60, "fill": "deep" },
-    { "id": "domeL", "type": "circle", "silhouette": true, "cx": 200, "cy": 252, "r": 40, "fill": "body" },
-    { "id": "domeR", "type": "circle", "silhouette": true, "cx": 314, "cy": 244, "r": 40, "fill": "body" },
+    {
+      "id": "domeL",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 200,
+      "cy": 252,
+      "r": 40,
+      "fill": "body"
+    },
+    {
+      "id": "domeR",
+      "type": "circle",
+      "silhouette": true,
+      "cx": 314,
+      "cy": 244,
+      "r": 40,
+      "fill": "body"
+    },
     { "id": "ringL", "type": "circle", "cx": 200, "cy": 252, "r": 26, "fill": "ring" },
     { "id": "ringR", "type": "circle", "cx": 314, "cy": 244, "r": 26, "fill": "ring" },
     { "id": "eyeL", "type": "circle", "cx": 206, "cy": 254, "r": 12, "fill": "ink" },
     { "id": "eyeR", "type": "circle", "cx": 308, "cy": 246, "r": 12, "fill": "ink" },
     { "id": "hiL", "type": "circle", "cx": 210, "cy": 249, "r": 4, "fill": "hi" },
     { "id": "hiR", "type": "circle", "cx": 312, "cy": 241, "r": 4, "fill": "hi" },
-    { "id": "mouth", "type": "path", "d": "M198 312 Q256 352 314 312", "fill": "none", "stroke": "ink", "strokeWidth": 8 }
+    {
+      "id": "mouth",
+      "type": "path",
+      "d": "M198 312 Q256 352 314 312",
+      "fill": "none",
+      "stroke": "ink",
+      "strokeWidth": 8
+    }
   ],
   "expressions": {
     "happy": {},
     "content": {
-      "eyeL": { "type": "path", "d": "M192 254 q14 -13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "eyeR": { "type": "path", "d": "M294 246 q14 -13 28 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M192 254 q14 -13 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M294 246 q14 -13 28 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "surprised": {
-      "eyeL": { "r": 15 }, "eyeR": { "r": 15 },
-      "mouth": { "type": "ellipse", "cx": 256, "cy": 322, "rx": 12, "ry": 13, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+      "eyeL": { "r": 15 },
+      "eyeR": { "r": 15 },
+      "mouth": {
+        "type": "ellipse",
+        "cx": 256,
+        "cy": 322,
+        "rx": 12,
+        "ry": 13,
+        "fill": "ink",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sleepy": {
-      "eyeL": { "type": "path", "d": "M188 252 q18 12 36 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "eyeR": { "type": "path", "d": "M290 244 q18 12 36 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null }
+      "eyeL": {
+        "type": "path",
+        "d": "M188 252 q18 12 36 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M290 244 q18 12 36 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null }
     },
     "wink": {
-      "eyeL": { "type": "path", "d": "M188 252 q18 12 36 0", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M188 252 q18 12 36 0",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
       "hiL": { "fill": null }
     },
     "excited": {
       "eyeL": { "r": 15 },
       "eyeR": { "r": 15 },
-      "mouth": { "type": "ellipse", "cx": 256, "cy": 322, "rx": 17, "ry": 14, "fill": "ink", "stroke": null, "strokeWidth": null, "d": null }
+      "mouth": {
+        "type": "ellipse",
+        "cx": 256,
+        "cy": 322,
+        "rx": 17,
+        "ry": 14,
+        "fill": "ink",
+        "stroke": null,
+        "strokeWidth": null,
+        "d": null
+      }
     },
     "sad": {
-      "eyeL": { "type": "path", "d": "M188 258 q18 -13 36 -6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "eyeR": { "type": "path", "d": "M290 244 q18 -7 36 6", "fill": "none", "stroke": "ink", "strokeWidth": 6, "r": null, "cx": null, "cy": null },
-      "hiL": { "fill": null }, "hiR": { "fill": null },
+      "eyeL": {
+        "type": "path",
+        "d": "M188 258 q18 -13 36 -6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "eyeR": {
+        "type": "path",
+        "d": "M290 244 q18 -7 36 6",
+        "fill": "none",
+        "stroke": "ink",
+        "strokeWidth": 6,
+        "r": null,
+        "cx": null,
+        "cy": null
+      },
+      "hiL": { "fill": null },
+      "hiR": { "fill": null },
       "mouth": { "d": "M214 328 Q256 300 298 328" }
     },
     "skeptical": {
@@ -74,8 +227,25 @@
     "idle": {
       "loop": true,
       "tracks": [
-        { "target": ["head", "body", "belly"], "property": "translateY", "keys": [[0, 0], [1.3, -2.5], [2.6, 0]] },
-        { "target": ["eyeL", "eyeR", "hiL", "hiR"], "property": "translateY", "keys": [[0, 0], [1.5, -3], [3, 3], [4.5, 0]] }
+        {
+          "target": ["head", "body", "belly"],
+          "property": "translateY",
+          "keys": [
+            [0, 0],
+            [1.3, -2.5],
+            [2.6, 0]
+          ]
+        },
+        {
+          "target": ["eyeL", "eyeR", "hiL", "hiR"],
+          "property": "translateY",
+          "keys": [
+            [0, 0],
+            [1.5, -3],
+            [3, 3],
+            [4.5, 0]
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
Closes #26

## What
Adds `.oxfmtrc.json` and runs `oxfmt --write` over the 1 files it covers.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 5 of 8, stacked on `vb-24-adopt-oxfmt-part4`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vb-24-adopt-oxfmt-part4                 -> 1 files, 220 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
