### PR TITLE
[VB-41] Adopt oxfmt as the formatter (part 2 of 2)

### DIFF
--- a/.github/workflows/oxfmt.yml
+++ b/.github/workflows/oxfmt.yml
@@ -1,0 +1,28 @@
+name: oxfmt
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  format:
+    name: oxfmt --check
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Check formatting
+        run: bunx oxfmt@0.65 --check .

--- a/mascot/branding-pack.mjs
+++ b/mascot/branding-pack.mjs
@@ -8,16 +8,21 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { renderTile, renderAvatar } from "./engine.js";
 
 const [, , specPath, outDir = ".", nameArg, tagArg] = process.argv;
-if (!specPath) { console.error("usage: branding-pack.mjs <spec> <outDir> [name] [tagline]"); process.exit(1); }
+if (!specPath) {
+  console.error("usage: branding-pack.mjs <spec> <outDir> [name] [tagline]");
+  process.exit(1);
+}
 const spec = JSON.parse(readFileSync(specPath, "utf8"));
 mkdirSync(outDir, { recursive: true });
 const P = spec.palette;
-const field = P.field, ink = P.ink || "#161616";
+const field = P.field,
+  ink = P.ink || "#161616";
 const title = nameArg || spec.name;
 const tagline = tagArg || "";
 
 // the character with no field, as an inner <g> we can place onto any canvas
-const glyph = (size) => renderAvatar(spec, { size, showField: false }).replace(/^<svg[^>]*>|<\/svg>$/g, "");
+const glyph = (size) =>
+  renderAvatar(spec, { size, showField: false }).replace(/^<svg[^>]*>|<\/svg>$/g, "");
 const [, , VW, VH] = spec.viewBox;
 
 // place the 0..VW glyph into a w×h canvas at (x,y) scaled to `gh` tall
@@ -26,53 +31,111 @@ function place(gh, x, y) {
   return `<g transform="translate(${x} ${y}) scale(${s})">${glyph(gh)}</g>`;
 }
 function textBlock({ x, y, big, small, colBig, colSmall }) {
-  const t = big ? `<text x="${x}" y="${y}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${big.size}" font-weight="800" fill="${colBig}" letter-spacing="-1">${big.t}</text>` : "";
-  const s = small ? `<text x="${x}" y="${y + (big ? big.size * 0.8 : 0)}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${small.size}" font-weight="500" fill="${colSmall}">${small.t}</text>` : "";
+  const t = big
+    ? `<text x="${x}" y="${y}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${big.size}" font-weight="800" fill="${colBig}" letter-spacing="-1">${big.t}</text>`
+    : "";
+  const s = small
+    ? `<text x="${x}" y="${y + (big ? big.size * 0.8 : 0)}" font-family="system-ui,Segoe UI,Roboto,sans-serif" font-size="${small.size}" font-weight="500" fill="${colSmall}">${small.t}</text>`
+    : "";
   return t + s;
 }
-const svg = (w, h, inner) => `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">${inner}</svg>\n`;
-const onWhite = c => "#ffffff";
-const write = (name, s) => { writeFileSync(`${outDir}/${name}`, s); console.log("  ", name); };
+const svg = (w, h, inner) =>
+  `<svg width="${w}" height="${h}" viewBox="0 0 ${w} ${h}" xmlns="http://www.w3.org/2000/svg">${inner}</svg>\n`;
+const onWhite = (c) => "#ffffff";
+const write = (name, s) => {
+  writeFileSync(`${outDir}/${name}`, s);
+  console.log("  ", name);
+};
 
 console.log(`${title} → ${outDir}`);
 
 // --- icons / favicons ---
 write("favicon.svg", renderTile(spec, { size: 64, shape: "round" }));
 write("icon-512.svg", renderTile(spec, { size: 512, shape: "round" }));
-write("icon-maskable-512.svg", svg(512, 512,
-  `<rect width="512" height="512" fill="${field}"/>` + `<g transform="translate(51.2 51.2) scale(0.8)">${renderTile(spec, { size: 512, shape: "round", bg: field }).replace(/^<svg[^>]*>|<\/svg>$/g, "")}</g>`));
+write(
+  "icon-maskable-512.svg",
+  svg(
+    512,
+    512,
+    `<rect width="512" height="512" fill="${field}"/>` +
+      `<g transform="translate(51.2 51.2) scale(0.8)">${renderTile(spec, { size: 512, shape: "round", bg: field }).replace(/^<svg[^>]*>|<\/svg>$/g, "")}</g>`,
+  ),
+);
 write("apple-touch-180.svg", renderTile(spec, { size: 180, shape: "round" }));
 
 // --- logo / mark ---
-write("logo-on-brand.svg", renderAvatar(spec, { size: 512 }));            // character on brand field
+write("logo-on-brand.svg", renderAvatar(spec, { size: 512 })); // character on brand field
 write("mark-transparent.svg", renderAvatar(spec, { size: 512, showField: false })); // raw character, no bg
 write("mark-outline.svg", renderAvatar(spec, { size: 512, showField: false, outline: field })); // safe on any page
 
 // --- profile pictures (square, 1:1) ---
 write("profile-512.svg", renderTile(spec, { size: 512, shape: "round" }));
-write("profile-square-512.svg", svg(512, 512, `<rect width="512" height="512" fill="${field}"/>${place(512, 40, 24)}`));
+write(
+  "profile-square-512.svg",
+  svg(512, 512, `<rect width="512" height="512" fill="${field}"/>${place(512, 40, 24)}`),
+);
 
 // --- Open Graph 1200×630 ---
-write("og-1200x630.svg", svg(1200, 630,
-  `<rect width="1200" height="630" fill="${field}"/>` +
-  place(430, 96, 100) +
-  textBlock({ x: 560, y: 300, big: { t: title, size: 84 }, small: tagline ? { t: tagline, size: 34 } : null, colBig: onWhite(), colSmall: "rgba(255,255,255,.82)" })));
+write(
+  "og-1200x630.svg",
+  svg(
+    1200,
+    630,
+    `<rect width="1200" height="630" fill="${field}"/>` +
+      place(430, 96, 100) +
+      textBlock({
+        x: 560,
+        y: 300,
+        big: { t: title, size: 84 },
+        small: tagline ? { t: tagline, size: 34 } : null,
+        colBig: onWhite(),
+        colSmall: "rgba(255,255,255,.82)",
+      }),
+  ),
+);
 
 // --- LinkedIn cover 1584×396 ---
-write("linkedin-cover-1584x396.svg", svg(1584, 396,
-  `<rect width="1584" height="396" fill="${field}"/>` +
-  place(320, 120, 40) +
-  textBlock({ x: 500, y: 190, big: { t: title, size: 66 }, small: tagline ? { t: tagline, size: 30 } : null, colBig: onWhite(), colSmall: "rgba(255,255,255,.82)" })));
+write(
+  "linkedin-cover-1584x396.svg",
+  svg(
+    1584,
+    396,
+    `<rect width="1584" height="396" fill="${field}"/>` +
+      place(320, 120, 40) +
+      textBlock({
+        x: 500,
+        y: 190,
+        big: { t: title, size: 66 },
+        small: tagline ? { t: tagline, size: 30 } : null,
+        colBig: onWhite(),
+        colSmall: "rgba(255,255,255,.82)",
+      }),
+  ),
+);
 
 // --- X / Twitter header 1500×500 ---
-write("x-header-1500x500.svg", svg(1500, 500,
-  `<rect width="1500" height="500" fill="${field}"/>` +
-  place(360, 150, 70) +
-  textBlock({ x: 560, y: 250, big: { t: title, size: 72 }, small: tagline ? { t: tagline, size: 32 } : null, colBig: onWhite(), colSmall: "rgba(255,255,255,.82)" })));
+write(
+  "x-header-1500x500.svg",
+  svg(
+    1500,
+    500,
+    `<rect width="1500" height="500" fill="${field}"/>` +
+      place(360, 150, 70) +
+      textBlock({
+        x: 560,
+        y: 250,
+        big: { t: title, size: 72 },
+        small: tagline ? { t: tagline, size: 32 } : null,
+        colBig: onWhite(),
+        colSmall: "rgba(255,255,255,.82)",
+      }),
+  ),
+);
 
 // --- pack README ---
-write("README.md",
-`# ${title} — brand assets
+write(
+  "README.md",
+  `# ${title} — brand assets
 
 Generated from \`${spec.name}.avatar.json\` by vibebrand's mascot engine. All SVG
 (scalable). Rasterize to PNG where a platform needs it.
@@ -90,6 +153,7 @@ Generated from \`${spec.name}.avatar.json\` by vibebrand's mascot engine. All SV
 | \`x-header-1500x500.svg\` | X / Twitter header |
 
 Brand field \`${field}\`. Regenerate: \`node vibebrand/mascot/branding-pack.mjs ${spec.name}.avatar.json <out> "${title}" "${tagline}"\`
-`);
+`,
+);
 
 console.log("done");

--- a/mascot/build.mjs
+++ b/mascot/build.mjs
@@ -7,11 +7,17 @@ import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { renderTile, renderAvatar } from "./engine.js";
 
 const [, , specPath, outDir = "."] = process.argv;
-if (!specPath) { console.error("usage: build.mjs <spec.avatar.json> <outDir>"); process.exit(1); }
+if (!specPath) {
+  console.error("usage: build.mjs <spec.avatar.json> <outDir>");
+  process.exit(1);
+}
 const spec = JSON.parse(readFileSync(specPath, "utf8"));
 mkdirSync(outDir, { recursive: true });
 
-const write = (name, svg) => { writeFileSync(`${outDir}/${name}`, svg + "\n"); console.log("wrote", `${outDir}/${name}`); };
+const write = (name, svg) => {
+  writeFileSync(`${outDir}/${name}`, svg + "\n");
+  console.log("wrote", `${outDir}/${name}`);
+};
 write("favicon.svg", renderTile(spec, { size: 64, shape: "round" }));
 write("icon.svg", renderTile(spec, { size: 512, shape: "round" }));
 write("logo.svg", renderAvatar(spec, { size: 512 }));

--- a/mascot/engine.js
+++ b/mascot/engine.js
@@ -34,29 +34,37 @@ let _cid = 0;
 // brand-lab.html's innerHTML). Escape every spec-derived value used inside a
 // markup attribute or text node to prevent it breaking out into new markup.
 const ESCAPE_MAP = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
-const esc = v => String(v).replace(/[&<>"']/g, c => ESCAPE_MAP[c]);
+const esc = (v) => String(v).replace(/[&<>"']/g, (c) => ESCAPE_MAP[c]);
 
-const color = (pal, key) => esc((key && pal[key]) ? pal[key] : (key || "none"));
-const isSet = v => v !== null && v !== undefined;
+const color = (pal, key) => esc(key && pal[key] ? pal[key] : key || "none");
+const isSet = (v) => v !== null && v !== undefined;
 
 function attrRotate(p) {
-  return p.rotate ? ` transform="rotate(${esc(p.rotate)} ${esc(p.cx ?? 0)} ${esc(p.cy ?? 0)})"` : "";
+  return p.rotate
+    ? ` transform="rotate(${esc(p.rotate)} ${esc(p.cx ?? 0)} ${esc(p.cy ?? 0)})"`
+    : "";
 }
 function attrStroke(pal, p) {
   const s = p.stroke && pal[p.stroke] ? pal[p.stroke] : p.stroke;
   if (!s || s === "none") return "";
-  return ` stroke="${esc(s)}" stroke-linecap="round" stroke-linejoin="round"` +
-         (p.strokeWidth ? ` stroke-width="${esc(p.strokeWidth)}"` : "");
+  return (
+    ` stroke="${esc(s)}" stroke-linecap="round" stroke-linejoin="round"` +
+    (p.strokeWidth ? ` stroke-width="${esc(p.strokeWidth)}"` : "")
+  );
 }
 
 // Render one part to an SVG element string.
 export function renderPart(p, pal) {
   const fill = color(pal, p.fill);
-  const st = attrStroke(pal, p), rot = attrRotate(p);
+  const st = attrStroke(pal, p),
+    rot = attrRotate(p);
   switch (p.type) {
     case "rect":
-      return `<rect x="${esc(p.x)}" y="${esc(p.y)}" width="${esc(p.w)}" height="${esc(p.h)}"` +
-        (isSet(p.rx) ? ` rx="${esc(p.rx)}"` : "") + ` fill="${fill}"${st}${rot}/>`;
+      return (
+        `<rect x="${esc(p.x)}" y="${esc(p.y)}" width="${esc(p.w)}" height="${esc(p.h)}"` +
+        (isSet(p.rx) ? ` rx="${esc(p.rx)}"` : "") +
+        ` fill="${fill}"${st}${rot}/>`
+      );
     case "ellipse":
       return `<ellipse cx="${esc(p.cx)}" cy="${esc(p.cy)}" rx="${esc(p.rx)}" ry="${esc(p.ry)}" fill="${fill}"${st}${rot}/>`;
     case "circle":
@@ -64,9 +72,12 @@ export function renderPart(p, pal) {
     case "path":
       return `<path d="${esc(p.d)}" fill="${fill}"${st}${rot}/>`;
     case "text":
-      return `<text x="${esc(p.x)}" y="${esc(p.y)}" font-size="${esc(p.size)}"` +
+      return (
+        `<text x="${esc(p.x)}" y="${esc(p.y)}" font-size="${esc(p.size)}"` +
         (p.weight ? ` font-weight="${esc(p.weight)}"` : "") +
-        (p.italic ? ` font-style="italic"` : "") + ` fill="${fill}"${st}${rot}>${esc(p.text)}</text>`;
+        (p.italic ? ` font-style="italic"` : "") +
+        ` fill="${fill}"${st}${rot}>${esc(p.text)}</text>`
+      );
     default:
       return "";
   }
@@ -76,7 +87,7 @@ export function renderPart(p, pal) {
 // the property (so a spec can turn an ellipse eye into a path arc, etc.).
 function applyExpression(parts, expr) {
   const ov = expr || {};
-  return parts.map(p => {
+  return parts.map((p) => {
     if (!ov[p.id]) return p;
     const merged = { ...p, ...ov[p.id] };
     for (const k of Object.keys(ov[p.id])) if (ov[p.id][k] === null) delete merged[k];
@@ -92,7 +103,10 @@ function viewBoxOf(spec) {
   return { x0, y0, w, h, vb: spec.viewBox.join(" ") };
 }
 function splitField(parts) {
-  return { fieldPart: parts.find(p => p.id === "field"), rest: parts.filter(p => p.id !== "field") };
+  return {
+    fieldPart: parts.find((p) => p.id === "field"),
+    rest: parts.filter((p) => p.id !== "field"),
+  };
 }
 function paintField(fieldPart, pal, showField = true) {
   return showField && fieldPart ? renderPart(fieldPart, pal) : "";
@@ -113,26 +127,32 @@ function svgAt(size, viewBox, inner) {
 // touch about the focus point, in one flat color. Works for any animal because
 // it never assumes a shape — it just inflates the silhouette group.
 function outlineLayer({ parts, focus, colorHex, amount = 0.045 }) {
-  const sil = parts.filter(p => p.silhouette);
+  const sil = parts.filter((p) => p.silhouette);
   if (!sil.length) return "";
-  const inked = sil.map(p => renderPart({ ...p, fill: "__o", stroke: undefined }, { __o: colorHex })).join("");
-  const s = 1 + amount, cx = focus?.cx ?? 200, cy = focus?.cy ?? 200;
+  const inked = sil
+    .map((p) => renderPart({ ...p, fill: "__o", stroke: undefined }, { __o: colorHex }))
+    .join("");
+  const s = 1 + amount,
+    cx = focus?.cx ?? 200,
+    cy = focus?.cy ?? 200;
   return `<g transform="translate(${cx - s * cx} ${cy - s * cy}) scale(${s})">${inked}</g>`;
 }
 function maybeOutline(parts, focus, outline) {
   return outline ? outlineLayer({ parts, focus, colorHex: outline }) : "";
 }
 function accessoryParts(spec, accessory, pal) {
-  return (spec.accessories?.[accessory] || []).map(p => renderPart(p, pal)).join("");
+  return (spec.accessories?.[accessory] || []).map((p) => renderPart(p, pal)).join("");
 }
 function headTurnX(headTurn) {
   return Math.round(Math.max(-1, Math.min(1, +headTurn || 0)) * 18 * 100) / 100;
 }
 function paintParts(parts, pal, dx) {
-  return parts.map(p => {
-    const el = renderPart(p, pal);
-    return dx && !p.silhouette ? `<g transform="translate(${esc(dx)} 0)">${el}</g>` : el;
-  }).join("");
+  return parts
+    .map((p) => {
+      const el = renderPart(p, pal);
+      return dx && !p.silhouette ? `<g transform="translate(${esc(dx)} 0)">${el}</g>` : el;
+    })
+    .join("");
 }
 function maybeFlip(flip, x0, w, inner) {
   return flip ? `<g transform="translate(${esc(2 * x0 + w)} 0) scale(-1 1)">${inner}</g>` : inner;
@@ -153,7 +173,16 @@ function tileFocus(spec, { x0, y0, w, h }) {
 //   flip (bool) — mirror the whole character horizontally about the viewBox
 //     center (wraps the tilt group in scale(-1,1)). Both default to no-ops.
 export function renderAvatar(spec, opts = {}) {
-  const { expression, accessory, field = "field", size = 240, outline = null, showField = true, headTurn = 0, flip = false } = opts;
+  const {
+    expression,
+    accessory,
+    field = "field",
+    size = 240,
+    outline = null,
+    showField = true,
+    headTurn = 0,
+    flip = false,
+  } = opts;
   const pal = paletteFor(spec, field);
   const box = viewBoxOf(spec);
   const parts = applyExpression(spec.parts, spec.expressions?.[expression]);
@@ -169,20 +198,28 @@ export function renderAvatar(spec, opts = {}) {
 // Guarantees the icon can never drift from the character — it is the character.
 export function renderTile(spec, opts = {}) {
   const { size = 64, shape = "round", radius = 0.23, field = "field", bg } = opts;
-  const id = "m" + (_cid++);
-  const box = viewBoxOf(spec), { w, h } = box;
+  const id = "m" + _cid++;
+  const box = viewBoxOf(spec),
+    { w, h } = box;
   const f = tileFocus(spec, box);
-  const s = f.scale ?? 0.9, cx = w / 2, cy = h * 0.52;
+  const s = f.scale ?? 0.9,
+    cx = w / 2,
+    cy = h * 0.52;
   const fill = esc(bg || paletteFor(spec, field).field);
   const inner = renderAvatar(spec, { size, showField: false }).replace(/^<svg[^>]*>|<\/svg>$/g, "");
-  return svgAt(size, `0 0 ${w} ${h}`,
+  return svgAt(
+    size,
+    `0 0 ${w} ${h}`,
     `<defs><clipPath id="${id}">${tileShape(shape, w, h, radius)}</clipPath></defs>` +
-    `<g clip-path="url(#${id})"><rect width="${w}" height="${h}" fill="${fill}"/>` +
-    `<g transform="translate(${cx - s * f.cx} ${cy - s * f.cy}) scale(${s})">${inner}</g></g>`);
+      `<g clip-path="url(#${id})"><rect width="${w}" height="${h}" fill="${fill}"/>` +
+      `<g transform="translate(${cx - s * f.cx} ${cy - s * f.cy}) scale(${s})">${inner}</g></g>`,
+  );
 }
 
 // ---- expression sheet -------------------------------------------------------
-export function expressionNames(spec) { return Object.keys(spec.expressions || { happy: {} }); }
+export function expressionNames(spec) {
+  return Object.keys(spec.expressions || { happy: {} });
+}
 
 function idleUnit(property) {
   if (property === "rotate") return "deg";
@@ -199,29 +236,37 @@ function idleIter(idle) {
 }
 function compileOneTrack(t, i, iid, cls) {
   if (!t.keys?.length) return "";
-  const name = iid + "k" + i, unit = idleUnit(t.property);
+  const name = iid + "k" + i,
+    unit = idleUnit(t.property);
   const dur = t.keys[t.keys.length - 1][0];
   if (!(dur > 0)) return "";
-  const frames = t.keys.map(([time, v]) => {
-    const pct = (time / dur * 100).toFixed(1);
-    return `${pct}%{transform:${idleTransform(t.property, v, unit)}}`;
-  }).join("");
+  const frames = t.keys
+    .map(([time, v]) => {
+      const pct = ((time / dur) * 100).toFixed(1);
+      return `${pct}%{transform:${idleTransform(t.property, v, unit)}}`;
+    })
+    .join("");
   const targets = Array.isArray(t.target) ? t.target : [t.target];
-  targets.forEach(id => { (cls[id] = cls[id] || []).push({ name, dur }); });
+  targets.forEach((id) => {
+    (cls[id] = cls[id] || []).push({ name, dur });
+  });
   return `@keyframes ${name}{${frames}}`;
 }
 function compileIdleTracks(tracks, iid, cls) {
   let css = "";
-  (tracks || []).forEach((t, i) => { css += compileOneTrack(t, i, iid, cls); });
+  (tracks || []).forEach((t, i) => {
+    css += compileOneTrack(t, i, iid, cls);
+  });
   return css;
 }
 function originOf(p) {
-  const ox = isSet(p.cx) ? `${esc(p.cx)}px` : "50%", oy = isSet(p.cy) ? `${esc(p.cy)}px` : "50%";
+  const ox = isSet(p.cx) ? `${esc(p.cx)}px` : "50%",
+    oy = isSet(p.cy) ? `${esc(p.cy)}px` : "50%";
   return `${ox} ${oy}`;
 }
 function wrapIdlePart(p, el, anims, iter) {
   if (!anims) return el;
-  const anim = anims.map(x => `${esc(x.name)} ${esc(x.dur)}s ease-in-out ${iter}`).join(",");
+  const anim = anims.map((x) => `${esc(x.name)} ${esc(x.dur)}s ease-in-out ${iter}`).join(",");
   return `<g class="cr-${esc(p.id)}" style="animation:${anim};transform-box:view-box;transform-origin:${originOf(p)}">${el}</g>`;
 }
 
@@ -234,14 +279,18 @@ export function renderIdle(spec, opts = {}) {
   const box = viewBoxOf(spec);
   const idle = spec.animations?.idle;
   const { fieldPart, rest } = splitField(spec.parts);
-  const iid = "m" + (_cid++); // unique per call, so keyframe names never collide across mascots on one page
+  const iid = "m" + _cid++; // unique per call, so keyframe names never collide across mascots on one page
   const iter = idleIter(idle);
   const cls = {}; // partId -> [animName...]
-  const css = "@media(prefers-reduced-motion:reduce){[class^=cr-]{animation:none!important}}" +
+  const css =
+    "@media(prefers-reduced-motion:reduce){[class^=cr-]{animation:none!important}}" +
     compileIdleTracks(idle?.tracks, iid, cls);
-  const body = rest.map(p => wrapIdlePart(p, renderPart(p, pal), cls[p.id], iter)).join("");
-  return svgAt(size, `${box.x0} ${box.y0} ${box.w} ${box.h}`,
-    `<style>${css}</style>` + paintField(fieldPart, pal) + withTilt(spec, box, body));
+  const body = rest.map((p) => wrapIdlePart(p, renderPart(p, pal), cls[p.id], iter)).join("");
+  return svgAt(
+    size,
+    `${box.x0} ${box.y0} ${box.w} ${box.h}`,
+    `<style>${css}</style>` + paintField(fieldPart, pal) + withTilt(spec, box, body),
+  );
 }
 
 // ---- seeded roster (deterministic variants from one spec) ------------------
@@ -286,10 +335,14 @@ function hexToRgb(hex) {
   return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
 }
 function rgbToHsl(r, g, b) {
-  r /= 255; g /= 255; b /= 255;
-  const mx = Math.max(r, g, b), mn = Math.min(r, g, b);
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const mx = Math.max(r, g, b),
+    mn = Math.min(r, g, b);
   const l = (mx + mn) / 2;
-  let h = 0, s = 0;
+  let h = 0,
+    s = 0;
   if (mx !== mn) {
     const d = mx - mn;
     s = l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
@@ -311,17 +364,19 @@ function hue2rgb(p, q, t) {
 }
 
 function hslToRgbStr({ h, s, l }) {
-  h /= 360; s /= 100; l /= 100;
+  h /= 360;
+  s /= 100;
+  l /= 100;
   if (s === 0) {
     const g = Math.round(l * 255);
-    return "#" + [g, g, g].map(v => v.toString(16).padStart(2, "0")).join("");
+    return "#" + [g, g, g].map((v) => v.toString(16).padStart(2, "0")).join("");
   }
   const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
   const p = 2 * l - q;
   const r = Math.round(hue2rgb(p, q, h + 1 / 3) * 255);
   const g = Math.round(hue2rgb(p, q, h) * 255);
   const b = Math.round(hue2rgb(p, q, h - 1 / 3) * 255);
-  return "#" + [r, g, b].map(v => v.toString(16).padStart(2, "0")).join("");
+  return "#" + [r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("");
 }
 // #rgb, #rgba, #rrggbb, #rrggbbaa — the forms hexToRgb can actually read.
 const HEX_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
@@ -337,7 +392,7 @@ function rotateHex(hex, degrees) {
   }
   const { r, g, b } = hexToRgb(hex);
   const hsl = rgbToHsl(r, g, b);
-  hsl.h = ((hsl.h + degrees) % 360 + 360) % 360;
+  hsl.h = (((hsl.h + degrees) % 360) + 360) % 360;
   return hslToRgbStr(hsl);
 }
 
@@ -359,7 +414,7 @@ function rotatePalette(palette, hueOff) {
 // a roster one character rather than a set of unrelated creatures.
 const JITTERED = ["rx", "ry", "cx", "cy"];
 function jitterSilhouettes(parts, seed, jitter) {
-  return parts.map(part => {
+  return parts.map((part) => {
     const p = { ...part };
     if (!p.silhouette) return p;
     for (const prop of JITTERED) {
@@ -412,11 +467,20 @@ export function variantSpec(spec, seed, opts = {}) {
 
 // Render a roster of variants — one per seed.
 export function renderRoster(spec, seeds, opts = {}) {
-  return seeds.map(seed => ({
+  return seeds.map((seed) => ({
     seed,
-    svg: renderAvatar(variantSpec(spec, seed, opts), opts)
+    svg: renderAvatar(variantSpec(spec, seed, opts), opts),
   }));
 }
 
 // Convenience for Node consumers: everything in one namespace.
-export default { renderPart, renderAvatar, renderTile, renderIdle, expressionNames, seededTrait, variantSpec, renderRoster };
+export default {
+  renderPart,
+  renderAvatar,
+  renderTile,
+  renderIdle,
+  expressionNames,
+  seededTrait,
+  variantSpec,
+  renderRoster,
+};

--- a/mascot/engine.test.mjs
+++ b/mascot/engine.test.mjs
@@ -1,11 +1,7 @@
 // vibebrand · mascot engine tests (node:test, zero dependencies)
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import {
-  seededTrait,
-  variantSpec,
-  renderRoster,
-} from "./engine.js";
+import { seededTrait, variantSpec, renderRoster } from "./engine.js";
 
 // Quiet helper: load the reference spec without import assertions
 import { readFileSync } from "node:fs";
@@ -68,13 +64,19 @@ describe("variantSpec – palette", () => {
     }
     // With 5 seeds and 10 hue slots, probability all 5 hit the same offset is
     // 10 * (1/10)^5 = 0.001 — practically guaranteed to see at least 2 distinct.
-    assert(colors.size > 1, `expected at least 2 distinct body colors across 5 seeds, got ${colors.size}`);
+    assert(
+      colors.size > 1,
+      `expected at least 2 distinct body colors across 5 seeds, got ${colors.size}`,
+    );
   });
 
   it("ink is never hue-rotated", () => {
     for (const seed of ["alice", "bob", "carol", "dave", "eve"]) {
-      assert.strictEqual(variantSpec(spec, seed).palette.ink, spec.palette.ink,
-        `ink changed for seed ${seed}`);
+      assert.strictEqual(
+        variantSpec(spec, seed).palette.ink,
+        spec.palette.ink,
+        `ink changed for seed ${seed}`,
+      );
     }
   });
 
@@ -84,24 +86,29 @@ describe("variantSpec – palette", () => {
     for (const seed of seeds) {
       colors.add(variantSpec(spec, seed).palette.body);
     }
-    assert(colors.size <= DEFAULT_HUES.length,
-      `expected ≤${DEFAULT_HUES.length} distinct body colours, got ${colors.size}`);
+    assert(
+      colors.size <= DEFAULT_HUES.length,
+      `expected ≤${DEFAULT_HUES.length} distinct body colours, got ${colors.size}`,
+    );
   });
 });
 
 describe("variantSpec – silhouette", () => {
   it("face parts (no silhouette:true) are geometrically unchanged vs the source", () => {
     const faceIds = new Set(["eyeL", "eyeR", "nose", "mouth"]);
-    const sourceParts = spec.parts.filter(p => faceIds.has(p.id));
+    const sourceParts = spec.parts.filter((p) => faceIds.has(p.id));
 
     for (const seed of ["alice", "bob", "carol"]) {
       const variant = variantSpec(spec, seed);
       for (const sp of sourceParts) {
-        const vp = variant.parts.find(p => p.id === sp.id);
+        const vp = variant.parts.find((p) => p.id === sp.id);
         for (const k of Object.keys(sp)) {
           if (k === "id") continue;
-          assert.strictEqual(vp[k], sp[k],
-            `face part "${sp.id}" property "${k}" changed for seed "${seed}": ${vp[k]} !== ${sp[k]}`);
+          assert.strictEqual(
+            vp[k],
+            sp[k],
+            `face part "${sp.id}" property "${k}" changed for seed "${seed}": ${vp[k]} !== ${sp[k]}`,
+          );
         }
       }
     }
@@ -117,8 +124,8 @@ describe("variantSpec – silhouette", () => {
     for (const seed of ["jittertest1", "jittertest2", "jittertest3"]) {
       const variant = variantSpec(spec, seed);
       for (const id of silIds) {
-        const orig = spec.parts.find(p => p.id === id);
-        const vp = variant.parts.find(p => p.id === id);
+        const orig = spec.parts.find((p) => p.id === id);
+        const vp = variant.parts.find((p) => p.id === id);
         for (const prop of ["rx", "ry", "cx", "cy"]) {
           if (orig[prop] === undefined) continue;
           // Jittered values should differ — because the offset is non-zero and
@@ -150,7 +157,7 @@ describe("renderRoster", () => {
   });
 
   it("two different seeds produce different SVG output", () => {
-    const [a, b] = renderRoster(spec, ["alice", "bob"]).map(e => e.svg);
+    const [a, b] = renderRoster(spec, ["alice", "bob"]).map((e) => e.svg);
     // Palette differs so SVGs must differ
     assert.notStrictEqual(a, b);
   });
@@ -178,11 +185,11 @@ describe("variantSpec – opts passthrough", () => {
     const v1 = variantSpec(spec, "alice", { jitter: 0 });
     const v2 = variantSpec(spec, "alice", { jitter: 0.2 });
     // With jitter=0, geometry should match source exactly
-    const origBody = spec.parts.find(p => p.id === "body");
-    const v1Body = v1.parts.find(p => p.id === "body");
+    const origBody = spec.parts.find((p) => p.id === "body");
+    const v1Body = v1.parts.find((p) => p.id === "body");
     assert.strictEqual(v1Body.cx, origBody.cx, "jitter=0 should leave cx unchanged");
     // With jitter=0.2 they should differ
-    const v2Body = v2.parts.find(p => p.id === "body");
+    const v2Body = v2.parts.find((p) => p.id === "body");
     assert.notStrictEqual(v2Body.cx, origBody.cx);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,17 +2,8 @@
 import { writeFileSync } from "node:fs";
 
 import { DIRECTIONS, getDirection } from "./catalog.js";
-import {
-  renderTokensCss,
-  renderTokensJson,
-  googleFontsHref,
-  checkContrast,
-} from "./tokens.js";
-import {
-  renderLogoSvg,
-  renderTailwindTheme,
-  renderInitFiles,
-} from "./generators.js";
+import { renderTokensCss, renderTokensJson, googleFontsHref, checkContrast } from "./tokens.js";
+import { renderLogoSvg, renderTailwindTheme, renderInitFiles } from "./generators.js";
 import type { BrandDirection } from "./catalog.js";
 
 const [cmd, arg, arg2] = process.argv.slice(2);
@@ -27,7 +18,9 @@ function listDirections() {
 function need(id: string | undefined) {
   const d = id ? getDirection(id) : undefined;
   if (!d) {
-    console.error(`unknown direction: ${id ?? "(none)"}\nrun \`vibebrand directions\` to list them.`);
+    console.error(
+      `unknown direction: ${id ?? "(none)"}\nrun \`vibebrand directions\` to list them.`,
+    );
     process.exit(1);
   }
   return d;
@@ -64,7 +57,8 @@ switch (cmd) {
     break;
   }
   case "check": {
-    const targets: BrandDirection[] = arg === "--all" || arg === undefined ? DIRECTIONS : [need(arg)];
+    const targets: BrandDirection[] =
+      arg === "--all" || arg === undefined ? DIRECTIONS : [need(arg)];
     let failed = 0;
     for (const d of targets) {
       const checks = checkContrast(d);
@@ -73,7 +67,9 @@ switch (cmd) {
       const mark = bad.length === 0 ? "PASS" : "FAIL";
       console.log(`\n${mark}  ${d.id} — ${d.name}`);
       for (const c of checks) {
-        console.log(`  ${c.pass ? "ok " : "XX "} ${c.ratio.toFixed(2).padStart(5)}:1  ${c.level.padEnd(8)}  ${c.pair}`);
+        console.log(
+          `  ${c.pass ? "ok " : "XX "} ${c.ratio.toFixed(2).padStart(5)}:1  ${c.level.padEnd(8)}  ${c.pair}`,
+        );
       }
     }
     if (failed > 0) {

--- a/src/contrast.ts
+++ b/src/contrast.ts
@@ -75,7 +75,8 @@ export function _selfCheck(): void {
   if (Math.abs(wb - 21) > 0.5) throw new Error(`white/black should be ~21, got ${wb.toFixed(2)}`);
   if (contrastRatio(black, black) > 1.01) throw new Error("same color must be ~1");
   // mid grey on white is a known ~AA-ish anchor: just assert ordering sanity
-  if (relativeLuminance(white) <= relativeLuminance(black)) throw new Error("white must be brighter than black");
+  if (relativeLuminance(white) <= relativeLuminance(black))
+    throw new Error("white must be brighter than black");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -21,10 +21,16 @@ export function renderLogoSvg(d: BrandDirection, theme: "light" | "dark" = "ligh
 }
 
 /** Primary lockup as inline SVG: mark + wordmark. */
-export function renderLockupSvg(d: BrandDirection, name: string, theme: "light" | "dark" = "light"): string {
+export function renderLockupSvg(
+  d: BrandDirection,
+  name: string,
+  theme: "light" | "dark" = "light",
+): string {
   const p = d[theme];
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 32" role="img" aria-label="${name}">
-  ${renderLogoSvg(d, theme).replace(/^<svg[^>]*>|<\/svg>$/g, "").trim()}
+  ${renderLogoSvg(d, theme)
+    .replace(/^<svg[^>]*>|<\/svg>$/g, "")
+    .trim()}
   <text x="40" y="22" font-family="${d.fonts.display}, sans-serif" font-size="20" font-weight="700" fill="${p.fg}">${name}</text>
 </svg>`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,7 @@ export {
   pickOn,
   type ContrastCheck,
 } from "./tokens.js";
-export {
-  contrastRatio,
-  wcagLevel,
-  relativeLuminance,
-  type WcagLevel,
-} from "./contrast.js";
+export { contrastRatio, wcagLevel, relativeLuminance, type WcagLevel } from "./contrast.js";
 export {
   renderLogoSvg,
   renderLockupSvg,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -99,7 +99,12 @@ function checkPalette(p: Palette, theme: string): ContrastCheck[] {
   ];
   return pairs.map(([pair, a, b, min]) => {
     const ratio = contrastRatio(a, b);
-    return { pair, ratio: Math.round(ratio * 100) / 100, level: wcagLevel(ratio), pass: ratio >= min };
+    return {
+      pair,
+      ratio: Math.round(ratio * 100) / 100,
+      level: wcagLevel(ratio),
+      pass: ratio >= min,
+    };
   });
 }
 
@@ -118,8 +123,18 @@ export function renderTokensJson(d: BrandDirection) {
     shadows: shadowScale(d),
     fonts: d.fonts,
     color: {
-      light: { ...d.light, onPrimary: pickOn(d.light.primary), onSecondary: pickOn(d.light.secondary), onTertiary: pickOn(d.light.tertiary) },
-      dark: { ...d.dark, onPrimary: pickOn(d.dark.primary), onSecondary: pickOn(d.dark.secondary), onTertiary: pickOn(d.dark.tertiary) },
+      light: {
+        ...d.light,
+        onPrimary: pickOn(d.light.primary),
+        onSecondary: pickOn(d.light.secondary),
+        onTertiary: pickOn(d.light.tertiary),
+      },
+      dark: {
+        ...d.dark,
+        onPrimary: pickOn(d.dark.primary),
+        onSecondary: pickOn(d.dark.secondary),
+        onTertiary: pickOn(d.dark.tertiary),
+      },
     },
     contrast: checkContrast(d),
   };


### PR DESCRIPTION
Closes #41

## What
Adds `.oxfmtrc.json`, runs `oxfmt --write` over the 10 files it covers, and adds `.github/workflows/oxfmt.yml` so CI fails on unformatted code.

## Why
The 2026-08-31 fleet audit found oxfmt in zero of the 48 pooriaarab repos that
carry JS/TS, against oxlint in 40. One formatter, enforced in CI, removes a class
of review noise that agent-authored diffs generate constantly.

`ignorePatterns` excludes vendor, third_party, generated, minified and build
output. Without it the formatter rewrites dependencies: on foxcade that was
141,361 lines, of which roughly 87,000 were `three.module.js` and `maplibre-gl`.

Part 2 of 2, stacked on `vb-39-adopt-oxfmt-part1`. Each part touches a disjoint set of files
so the parts do not conflict. Merge them in order.

## How I verified

```
npx oxfmt@0.65.0 --check .                 -> exit 0
npx oxlint@1.80.0 --config .oxlintrc.json  -> exit 0
git diff --numstat vb-39-adopt-oxfmt-part1                 -> 10 files, 440 lines
```

No source was hand-edited. Every change is `oxfmt --write` output.

Assisted-by: claude-personal-1:claude-opus-5
